### PR TITLE
Improve MFA setup UX and backup code handling

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -1,8 +1,8 @@
+Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:463,19F2E32
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:64,1BAB845
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:75,1D7A277
-Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:462,24EC5D0
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:10,4723B64
-Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:465,65C5E34
+Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:466,4B7D140
 XSS.SendResp: XSS in `send_resp`,lib/authify_web/controllers/saml_controller.ex:77,6B7E160
 XSS.SendResp: XSS in `send_resp`,lib/authify_web/controllers/saml_controller.ex:458,6CBB8FE
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:17,6E55B0E

--- a/lib/authify/mfa.ex
+++ b/lib/authify/mfa.ex
@@ -37,17 +37,31 @@ defmodule Authify.MFA do
       # Encrypt the secret for storage
       encrypted_secret = Encryption.encrypt(plaintext_secret)
 
-      # Generate backup codes
-      {plaintext_codes, hashed_codes} = generate_backup_codes()
+      # Only generate backup codes if user doesn't have any
+      # (e.g., this is their first MFA method or they have 0 codes remaining)
+      {plaintext_codes, changeset_updates} =
+        if backup_codes_count(user) == 0 do
+          {plaintext_codes, hashed_codes} = generate_backup_codes()
 
-      # Update user with encrypted secret and backup codes
-      user
-      |> Ecto.Changeset.change(%{
+          codes_updates = %{
+            totp_backup_codes: Jason.encode!(hashed_codes),
+            totp_backup_codes_generated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+          }
+
+          {plaintext_codes, codes_updates}
+        else
+          # User already has backup codes from another MFA method, don't overwrite
+          {[], %{}}
+        end
+
+      # Update user with encrypted secret and optionally backup codes
+      base_updates = %{
         totp_secret: encrypted_secret,
-        totp_enabled_at: DateTime.utc_now() |> DateTime.truncate(:second),
-        totp_backup_codes: Jason.encode!(hashed_codes),
-        totp_backup_codes_generated_at: DateTime.utc_now() |> DateTime.truncate(:second)
-      })
+        totp_enabled_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      }
+
+      user
+      |> Ecto.Changeset.change(Map.merge(base_updates, changeset_updates))
       |> Repo.update()
       |> case do
         {:ok, updated_user} -> {:ok, updated_user, plaintext_codes}
@@ -81,23 +95,41 @@ defmodule Authify.MFA do
   def verify_totp(%User{totp_secret: nil}, _code), do: {:error, :totp_not_enabled}
 
   @doc """
-  Disables TOTP for a user by clearing TOTP data and revoking all trusted devices.
+  Disables TOTP for a user by clearing TOTP data.
+  Only clears backup codes and revokes trusted devices if no other MFA methods remain.
   """
   def disable_totp(%User{} = user) do
     Repo.transaction(fn ->
-      # Clear TOTP data
+      # Check if user has other MFA methods (WebAuthn)
+      has_other_mfa = User.webauthn_enabled?(user)
+
+      # Build changeset - always clear TOTP-specific fields
+      changeset_updates = %{
+        totp_secret: nil,
+        totp_enabled_at: nil
+      }
+
+      # Only clear backup codes if no other MFA methods remain
+      changeset_updates =
+        if has_other_mfa do
+          changeset_updates
+        else
+          Map.merge(changeset_updates, %{
+            totp_backup_codes: nil,
+            totp_backup_codes_generated_at: nil
+          })
+        end
+
+      # Update user
       updated_user =
         user
-        |> Ecto.Changeset.change(%{
-          totp_secret: nil,
-          totp_enabled_at: nil,
-          totp_backup_codes: nil,
-          totp_backup_codes_generated_at: nil
-        })
+        |> Ecto.Changeset.change(changeset_updates)
         |> Repo.update!()
 
-      # Revoke all trusted devices
-      revoke_all_trusted_devices(user)
+      # Only revoke all trusted devices if no other MFA methods remain
+      unless has_other_mfa do
+        revoke_all_trusted_devices(user)
+      end
 
       updated_user
     end)

--- a/lib/authify/mfa/webauthn.ex
+++ b/lib/authify/mfa/webauthn.ex
@@ -248,7 +248,33 @@ defmodule Authify.MFA.WebAuthn do
       when is_binary(credential_id) or is_integer(credential_id) do
     case get_credential(credential_id) do
       {:ok, credential} ->
-        Repo.delete(credential)
+        user = Repo.get!(User, credential.user_id)
+
+        Repo.transaction(fn ->
+          # Delete the credential
+          {:ok, deleted_credential} = Repo.delete(credential)
+
+          # Check if user has other MFA methods
+          # (TOTP or other WebAuthn credentials)
+          has_totp = User.totp_enabled?(user)
+          remaining_webauthn = list_credentials(user) |> length()
+
+          # Only clear backup codes and revoke devices if no MFA methods remain
+          unless has_totp or remaining_webauthn > 0 do
+            # Clear backup codes
+            user
+            |> Ecto.Changeset.change(%{
+              totp_backup_codes: nil,
+              totp_backup_codes_generated_at: nil
+            })
+            |> Repo.update!()
+
+            # Revoke all trusted devices
+            Authify.MFA.revoke_all_trusted_devices(user)
+          end
+
+          deleted_credential
+        end)
 
       error ->
         error
@@ -259,12 +285,36 @@ defmodule Authify.MFA.WebAuthn do
   Revokes all WebAuthn credentials for a user.
   """
   def revoke_all_credentials(%User{} = user) do
-    {count, _} =
-      WebAuthnCredential
-      |> where([c], c.user_id == ^user.id)
-      |> Repo.delete_all()
+    Repo.transaction(fn ->
+      # Delete all WebAuthn credentials
+      {count, _} =
+        WebAuthnCredential
+        |> where([c], c.user_id == ^user.id)
+        |> Repo.delete_all()
 
-    {:ok, count}
+      # Check if user has other MFA methods (TOTP)
+      has_other_mfa = User.totp_enabled?(user)
+
+      # Only clear backup codes and revoke devices if no other MFA methods remain
+      unless has_other_mfa do
+        # Clear backup codes
+        user
+        |> Ecto.Changeset.change(%{
+          totp_backup_codes: nil,
+          totp_backup_codes_generated_at: nil
+        })
+        |> Repo.update!()
+
+        # Revoke all trusted devices
+        Authify.MFA.revoke_all_trusted_devices(user)
+      end
+
+      count
+    end)
+    |> case do
+      {:ok, count} -> {:ok, count}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   @doc """

--- a/lib/authify_web/controllers/mfa_controller.ex
+++ b/lib/authify_web/controllers/mfa_controller.ex
@@ -119,36 +119,62 @@ defmodule AuthifyWeb.MfaController do
       |> delete_session(:mfa_pending_user_id)
       |> delete_session(:mfa_pending_organization_id)
 
+    # Check if new backup codes were generated
+    # If backup_codes is empty, user already had codes from another MFA method
+    has_new_codes = not Enum.empty?(backup_codes)
+
     if mfa_setup_required do
-      # Mandatory setup complete - sign user in and show backup codes
-      conn
-      |> Authify.Guardian.Plug.sign_in(updated_user)
-      |> put_session(:current_organization_id, organization.id)
-      |> put_flash(
-        :info,
-        "Multi-factor authentication has been successfully enabled! Please save your backup codes before continuing."
-      )
-      |> render(:backup_codes,
-        user: updated_user,
-        organization: organization,
-        backup_codes: backup_codes,
-        show_download: true,
-        mandatory_setup: true
-      )
+      # Mandatory setup complete - sign user in
+      conn =
+        conn
+        |> Authify.Guardian.Plug.sign_in(updated_user)
+        |> put_session(:current_organization_id, organization.id)
+
+      if has_new_codes do
+        # Show backup codes for first MFA method
+        conn
+        |> put_flash(
+          :info,
+          "Multi-factor authentication has been successfully enabled! Please save your backup codes before continuing."
+        )
+        |> render(:backup_codes,
+          user: updated_user,
+          organization: organization,
+          backup_codes: backup_codes,
+          show_download: true,
+          mandatory_setup: true
+        )
+      else
+        # User already had codes, just redirect to dashboard
+        conn
+        |> put_flash(:info, "TOTP has been successfully enabled!")
+        |> redirect(to: get_dashboard_path_for_user(updated_user, organization))
+      end
     else
-      # Voluntary setup - show backup codes
-      conn
-      |> put_flash(
-        :info,
-        "Multi-factor authentication has been successfully enabled! Please save your backup codes."
-      )
-      |> render(:backup_codes,
-        user: updated_user,
-        organization: organization,
-        backup_codes: backup_codes,
-        show_download: true,
-        mandatory_setup: false
-      )
+      # Voluntary setup
+      if has_new_codes do
+        # Show backup codes for first MFA method
+        conn
+        |> put_flash(
+          :info,
+          "Multi-factor authentication has been successfully enabled! Please save your backup codes."
+        )
+        |> render(:backup_codes,
+          user: updated_user,
+          organization: organization,
+          backup_codes: backup_codes,
+          show_download: true,
+          mandatory_setup: false
+        )
+      else
+        # User already had codes from another MFA method, redirect to MFA settings
+        conn
+        |> put_flash(
+          :info,
+          "TOTP has been successfully enabled! Your existing backup codes can still be used."
+        )
+        |> redirect(to: ~p"/#{organization.slug}/profile/mfa")
+      end
     end
   end
 

--- a/lib/authify_web/controllers/mfa_html/show.html.heex
+++ b/lib/authify_web/controllers/mfa_html/show.html.heex
@@ -45,14 +45,22 @@
                 <span class="badge bg-secondary fs-6">Not Enabled</span>
               </p>
               <p class="text-muted mb-3">
-                Add an extra layer of security to your account with multi-factor authentication.
+                Add an extra layer of security to your account with multi-factor authentication. Choose your preferred method below:
               </p>
-              <a
-                href={~p"/#{@organization.slug}/profile/mfa/setup"}
-                class="btn btn-primary"
-              >
-                <i class="bi bi-shield-plus"></i> Setup Multi-Factor Authentication
-              </a>
+              <div class="d-grid gap-2 d-md-flex">
+                <a
+                  href={~p"/#{@organization.slug}/profile/mfa/setup"}
+                  class="btn btn-primary"
+                >
+                  <i class="bi bi-phone"></i> Setup Authenticator App (TOTP)
+                </a>
+                <a
+                  href={~p"/#{@organization.slug}/profile/webauthn/setup"}
+                  class="btn btn-primary"
+                >
+                  <i class="bi bi-shield-check"></i> Register Security Key (WebAuthn)
+                </a>
+              </div>
             <% end %>
           </div>
         </div>
@@ -193,7 +201,7 @@
           </div>
         </div>
 
-        <%= if Authify.Accounts.User.totp_enabled?(@user) do %>
+        <%= if Authify.Accounts.User.mfa_enabled?(@user) do %>
           <!-- Backup Codes Card -->
           <div class="card mt-3">
             <div class="card-header">
@@ -317,7 +325,7 @@
           </div>
         </div>
 
-        <%= if Authify.Accounts.User.totp_enabled?(@user) do %>
+        <%= if Authify.Accounts.User.mfa_enabled?(@user) do %>
           <div class="card mt-3">
             <div class="card-header">
               <h6 class="card-title mb-0">

--- a/lib/authify_web/controllers/profile_html/show.html.heex
+++ b/lib/authify_web/controllers/profile_html/show.html.heex
@@ -184,7 +184,7 @@
                 <i class="bi bi-key-fill"></i> Personal Access Tokens
               </a>
 
-              <%= if Authify.Accounts.User.totp_enabled?(@user) do %>
+              <%= if Authify.Accounts.User.mfa_enabled?(@user) do %>
                 <a
                   href={~p"/#{@current_organization.slug}/profile/mfa"}
                   class="btn btn-outline-secondary"
@@ -193,7 +193,7 @@
                 </a>
               <% else %>
                 <a
-                  href={~p"/#{@current_organization.slug}/profile/mfa/setup"}
+                  href={~p"/#{@current_organization.slug}/profile/mfa"}
                   class="btn btn-outline-secondary"
                 >
                   <i class="bi bi-shield-plus"></i> Setup MFA

--- a/lib/authify_web/controllers/webauthn_controller.ex
+++ b/lib/authify_web/controllers/webauthn_controller.ex
@@ -11,7 +11,7 @@ defmodule AuthifyWeb.WebAuthnController do
 
   import AuthifyWeb.Helpers.ConnHelpers, only: [get_client_ip: 1, get_user_agent: 1]
 
-  alias Authify.{Accounts, Repo}
+  alias Authify.{Accounts, MFA, Repo}
   alias Authify.Accounts.User
   alias Authify.MFA.WebAuthn
 
@@ -90,18 +90,8 @@ defmodule AuthifyWeb.WebAuthnController do
 
       case WebAuthn.complete_registration(current_user, attestation_response, challenge, opts) do
         {:ok, credential} ->
-          # Clear challenge from session
           conn = delete_session(conn, :webauthn_registration_challenge)
-
-          json(conn, %{
-            success: true,
-            message: "Security key registered successfully",
-            credential: %{
-              id: credential.id,
-              name: credential.name,
-              type: credential.credential_type
-            }
-          })
+          handle_successful_registration(conn, current_user, credential)
 
         {:error, reason} ->
           conn
@@ -121,6 +111,37 @@ defmodule AuthifyWeb.WebAuthnController do
   # ============================================================================
   # Credential Management
   # ============================================================================
+
+  @doc """
+  Display backup codes after WebAuthn setup (first MFA method).
+  """
+  def setup_complete(conn, _params) do
+    current_user = conn.assigns.current_user
+    organization = conn.assigns.current_organization
+
+    # Get backup codes from session
+    backup_codes = get_session(conn, :webauthn_setup_backup_codes)
+    setup_completed = get_session(conn, :webauthn_setup_completed)
+
+    if backup_codes && setup_completed do
+      # Clear session
+      conn =
+        conn
+        |> delete_session(:webauthn_setup_backup_codes)
+        |> delete_session(:webauthn_setup_completed)
+
+      render(conn, :backup_codes,
+        user: current_user,
+        organization: organization,
+        backup_codes: backup_codes,
+        show_download: true
+      )
+    else
+      conn
+      |> put_flash(:error, "No backup codes to display.")
+      |> redirect(to: ~p"/#{organization.slug}/profile/mfa")
+    end
+  end
 
   @doc """
   List all WebAuthn credentials for the current user.
@@ -246,6 +267,53 @@ defmodule AuthifyWeb.WebAuthnController do
   # ============================================================================
   # Private Helpers
   # ============================================================================
+
+  defp handle_successful_registration(conn, current_user, credential) do
+    organization = conn.assigns.current_organization
+    current_user = Repo.get!(User, current_user.id)
+
+    if needs_backup_codes?(current_user) do
+      handle_registration_with_backup_codes(conn, organization, credential)
+    else
+      json(conn, build_success_response(credential))
+    end
+  end
+
+  defp needs_backup_codes?(user) do
+    has_totp = User.totp_enabled?(user)
+    webauthn_count = length(WebAuthn.list_credentials(user))
+    !has_totp && webauthn_count == 1 && MFA.backup_codes_count(user) == 0
+  end
+
+  defp handle_registration_with_backup_codes(conn, organization, credential) do
+    case MFA.regenerate_backup_codes(Repo.get!(User, conn.assigns.current_user.id)) do
+      {:ok, _updated_user, backup_codes} ->
+        conn
+        |> put_session(:webauthn_setup_backup_codes, backup_codes)
+        |> put_session(:webauthn_setup_completed, true)
+        |> json(
+          Map.merge(build_success_response(credential), %{
+            show_backup_codes: true,
+            backup_codes_url: ~p"/#{organization.slug}/profile/webauthn/setup-complete"
+          })
+        )
+
+      {:error, _reason} ->
+        json(conn, build_success_response(credential))
+    end
+  end
+
+  defp build_success_response(credential) do
+    %{
+      success: true,
+      message: "Security key registered successfully",
+      credential: %{
+        id: credential.id,
+        name: credential.name,
+        type: credential.credential_type
+      }
+    }
+  end
 
   defp format_error(:invalid_challenge), do: "Invalid or expired challenge"
   defp format_error(:challenge_already_used), do: "Challenge has already been used"

--- a/lib/authify_web/controllers/webauthn_html/backup_codes.html.heex
+++ b/lib/authify_web/controllers/webauthn_html/backup_codes.html.heex
@@ -1,0 +1,143 @@
+<.two_column_layout flash={@flash}>
+  <:sidebar>
+    <.organization_sidebar
+      user={@user}
+      organization={@organization}
+      current_page="mfa"
+    />
+  </:sidebar>
+  <:main>
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+      <h1 class="h2">Backup Codes</h1>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-8">
+        <div class="card">
+          <div class="card-header bg-success text-white">
+            <h5 class="card-title mb-0">
+              <i class="bi bi-check-circle"></i> Security Key Registered Successfully
+            </h5>
+          </div>
+          <div class="card-body">
+            <div class="alert alert-info mb-4">
+              <h6><i class="bi bi-shield-check"></i> Your Account is Now Protected</h6>
+              <p class="mb-0">
+                You've successfully registered your security key. Backup codes allow you to access your account if you lose access to your security key.
+              </p>
+            </div>
+
+            <div class="alert alert-warning">
+              <h6><i class="bi bi-exclamation-triangle"></i> Save These Backup Codes</h6>
+              <p class="mb-0">
+                Each code can only be used once. Store them in a secure location like a password
+                manager. You won't be able to see these codes again.
+              </p>
+            </div>
+
+            <%= if @show_download do %>
+              <div class="mb-4 p-4 bg-light border rounded">
+                <h6 class="mb-3">Your Backup Codes:</h6>
+                <div class="row">
+                  <%= for code <- @backup_codes do %>
+                    <div class="col-md-6 mb-2">
+                      <code class="fs-5 user-select-all">{code}</code>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+
+              <div class="d-grid gap-2 d-md-flex justify-content-md-start mb-3">
+                <button
+                  type="button"
+                  class="btn btn-outline-primary"
+                  onclick="copyBackupCodes()"
+                >
+                  <i class="bi bi-clipboard"></i> Copy All Codes
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline-secondary"
+                  onclick="downloadBackupCodes()"
+                >
+                  <i class="bi bi-download"></i> Download as Text
+                </button>
+              </div>
+
+              <script>
+                function copyBackupCodes() {
+                  const codes = <%= Phoenix.HTML.raw(Jason.encode!(@backup_codes)) %>;
+                  const text = codes.join('\n');
+                  navigator.clipboard.writeText(text).then(() => {
+                    alert('Backup codes copied to clipboard!');
+                  });
+                }
+
+                function downloadBackupCodes() {
+                  const codes = <%= Phoenix.HTML.raw(Jason.encode!(@backup_codes)) %>;
+                  const text = 'Authify Backup Codes\n\n' + codes.join('\n') + '\n\nKeep these codes safe. Each code can only be used once.';
+                  const blob = new Blob([text], { type: 'text/plain' });
+                  const url = URL.createObjectURL(blob);
+                  const a = document.createElement('a');
+                  a.href = url;
+                  a.download = 'authify-backup-codes.txt';
+                  a.click();
+                  URL.revokeObjectURL(url);
+                }
+              </script>
+            <% end %>
+
+            <div class="d-grid gap-2">
+              <a
+                href={~p"/#{@organization.slug}/profile/mfa"}
+                class="btn btn-primary btn-lg"
+              >
+                <i class="bi bi-arrow-right"></i> Continue to MFA Settings
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-4">
+        <div class="card">
+          <div class="card-header">
+            <h6 class="card-title mb-0">
+              <i class="bi bi-info-circle"></i> How to Use Backup Codes
+            </h6>
+          </div>
+          <div class="card-body">
+            <ol class="mb-0 small">
+              <li class="mb-2">
+                During login, if you can't access your security key, click "Use Backup Code"
+              </li>
+              <li class="mb-2">Enter one of your backup codes</li>
+              <li class="mb-2">
+                The code will be consumed and can't be used again
+              </li>
+              <li class="mb-0">
+                Regenerate new codes from MFA settings if you're running low
+              </li>
+            </ol>
+          </div>
+        </div>
+
+        <div class="card mt-3">
+          <div class="card-header">
+            <h6 class="card-title mb-0">
+              <i class="bi bi-shield-check"></i> Storage Recommendations
+            </h6>
+          </div>
+          <div class="card-body">
+            <ul class="mb-0 small">
+              <li>Store in a password manager (1Password, Bitwarden, etc.)</li>
+              <li>Keep a printed copy in a secure location</li>
+              <li>Never share your backup codes with anyone</li>
+              <li>Don't store them in plain text on your computer</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </:main>
+</.two_column_layout>

--- a/lib/authify_web/controllers/webauthn_html/setup.html.heex
+++ b/lib/authify_web/controllers/webauthn_html/setup.html.heex
@@ -256,11 +256,17 @@
           csrfToken: document.querySelector('meta[name="csrf-token"]').content
         });
 
-        await registration.register(authenticatorType, credentialName);
+        const result = await registration.register(authenticatorType, credentialName);
 
         statusDiv.innerHTML = '<div class="alert alert-success">Security key registered successfully! Redirecting...</div>';
+
+        // Check if backup codes need to be shown
+        const redirectUrl = result.show_backup_codes && result.backup_codes_url
+          ? result.backup_codes_url
+          : '<%= ~p"/#{@organization.slug}/profile/mfa" %>';
+
         setTimeout(() => {
-          window.location.href = '<%= ~p"/#{@organization.slug}/profile/mfa" %>';
+          window.location.href = redirectUrl;
         }, 1500);
 
       } catch (error) {

--- a/lib/authify_web/router.ex
+++ b/lib/authify_web/router.ex
@@ -192,6 +192,7 @@ defmodule AuthifyWeb.Router do
     # WebAuthn credential management
     get "/profile/webauthn", WebAuthnController, :index
     get "/profile/webauthn/setup", WebAuthnController, :setup
+    get "/profile/webauthn/setup-complete", WebAuthnController, :setup_complete
     post "/profile/webauthn/register/begin", WebAuthnController, :register_begin
     post "/profile/webauthn/register/complete", WebAuthnController, :register_complete
     patch "/profile/webauthn/:id/rename", WebAuthnController, :rename

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.13.1",
+      version: "0.13.2",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/authify_web/controllers/mfa_controller_test.exs
+++ b/test/authify_web/controllers/mfa_controller_test.exs
@@ -382,7 +382,8 @@ defmodule AuthifyWeb.MfaControllerTest do
 
       assert html_response(conn, 200) =~ "Multi-Factor Authentication"
       assert html_response(conn, 200) =~ "Not Enabled"
-      assert html_response(conn, 200) =~ "Setup Multi-Factor Authentication"
+      assert html_response(conn, 200) =~ "Setup Authenticator App (TOTP)"
+      assert html_response(conn, 200) =~ "Register Security Key (WebAuthn)"
     end
 
     test "shows MFA status and management options for user with TOTP", %{


### PR DESCRIPTION
## Summary
Improves the multi-factor authentication (MFA) setup experience and fixes several issues with backup code handling.

## Changes

### 1. Improved MFA Setup Flow
- Changed "Setup MFA" button to redirect to MFA management page instead of directly to TOTP setup
- Users now see a choice between TOTP (Authenticator App) and WebAuthn (Security Keys) when setting up MFA
- Updated status check to use `mfa_enabled?` instead of `totp_enabled?` to properly detect any active MFA method

### 2. Fixed Backup Code Generation
- Backup codes are now only generated when enabling the **first** MFA method
- When adding a second MFA method (e.g., TOTP after WebAuthn), existing backup codes are preserved
- Added helpful flash messages to clarify when codes are reused vs newly generated

### 3. Fixed Backup Code Preservation
- Disabling TOTP now only clears backup codes if no other MFA methods remain (e.g., WebAuthn)
- Revoking WebAuthn credentials only clears backup codes if no other MFA methods remain (e.g., TOTP)
- Trusted devices are only revoked when the last MFA method is disabled

### 4. Added WebAuthn Backup Codes Page
- Created new backup codes display page for WebAuthn setup completion
- Matches the existing TOTP backup codes page for consistency

## Test plan
- [x] All tests pass (1466 tests, 0 failures)
- [x] Credo checks pass
- [x] Sobelow security scan passes
- [x] Code formatting verified

## Manual testing scenarios
1. User with no MFA enables TOTP → receives backup codes
2. User with TOTP adds WebAuthn → backup codes are preserved (not regenerated)
3. User with both TOTP and WebAuthn disables TOTP → backup codes remain
4. User with both TOTP and WebAuthn disables WebAuthn → backup codes remain
5. User with only TOTP disables it → backup codes are cleared
6. User with only WebAuthn revokes it → backup codes are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)