### PR TITLE
Reflect org-level OAuth 2.1 strict mode PKCE requirement on application pages

### DIFF
--- a/lib/authify_web/controllers/applications_controller.ex
+++ b/lib/authify_web/controllers/applications_controller.ex
@@ -2,6 +2,7 @@ defmodule AuthifyWeb.ApplicationsController do
   use AuthifyWeb, :controller
 
   alias Authify.AuditLog
+  alias Authify.Configurations
   alias Authify.OAuth
   alias Authify.OAuth.Application
 
@@ -45,13 +46,25 @@ defmodule AuthifyWeb.ApplicationsController do
   def show(conn, %{"id" => id}) do
     organization = conn.assigns.current_organization
     application = OAuth.get_oauth_application!(id, organization)
-    render(conn, :show, application: application, organization: organization)
+    org_strict_mode = Configurations.oauth_21_strict_mode?(organization)
+
+    render(conn, :show,
+      application: application,
+      organization: organization,
+      org_strict_mode: org_strict_mode
+    )
   end
 
   def new(conn, _params) do
     organization = conn.assigns.current_organization
     changeset = OAuth.change_application_form(%Application{})
-    render(conn, :new, changeset: changeset, organization: organization)
+    org_strict_mode = Configurations.oauth_21_strict_mode?(organization)
+
+    render(conn, :new,
+      changeset: changeset,
+      organization: organization,
+      org_strict_mode: org_strict_mode
+    )
   end
 
   def create(conn, %{"application" => application_params}) do
@@ -77,7 +90,13 @@ defmodule AuthifyWeb.ApplicationsController do
         )
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :new, changeset: changeset, organization: organization)
+        org_strict_mode = Configurations.oauth_21_strict_mode?(organization)
+
+        render(conn, :new,
+          changeset: changeset,
+          organization: organization,
+          org_strict_mode: org_strict_mode
+        )
     end
   end
 
@@ -86,11 +105,13 @@ defmodule AuthifyWeb.ApplicationsController do
     application = OAuth.get_oauth_application!(id, organization)
     # Use form_changeset instead of changeset to avoid applying default scopes
     changeset = OAuth.change_application_form(application)
+    org_strict_mode = Configurations.oauth_21_strict_mode?(organization)
 
     render(conn, :edit,
       application: application,
       changeset: changeset,
-      organization: organization
+      organization: organization,
+      org_strict_mode: org_strict_mode
     )
   end
 
@@ -115,10 +136,13 @@ defmodule AuthifyWeb.ApplicationsController do
         )
 
       {:error, %Ecto.Changeset{} = changeset} ->
+        org_strict_mode = Configurations.oauth_21_strict_mode?(organization)
+
         render(conn, :edit,
           application: application,
           changeset: changeset,
-          organization: organization
+          organization: organization,
+          org_strict_mode: org_strict_mode
         )
     end
   end

--- a/lib/authify_web/controllers/applications_html/application_form.html.heex
+++ b/lib/authify_web/controllers/applications_html/application_form.html.heex
@@ -256,9 +256,11 @@ https://app.example.com/oauth/callback"
         class="form-check-input"
         value="true"
         checked={
-          Map.get(@changeset.changes, :require_pkce) ||
+          @org_strict_mode ||
+            Map.get(@changeset.changes, :require_pkce) ||
             Map.get(@changeset.data, :require_pkce) || false
         }
+        disabled={@org_strict_mode}
       />
       <label class="form-check-label" for="application_require_pkce">
         Require PKCE
@@ -271,10 +273,19 @@ https://app.example.com/oauth/callback"
           <i class="bi bi-question-circle"></i>
         </button>
       </label>
-      <div class="form-text">
-        PKCE prevents authorization code interception attacks. Recommended for SPAs and mobile apps.
-        <em>Automatically enabled for public clients.</em>
-      </div>
+      <%= if @org_strict_mode do %>
+        <div class="form-text">
+          <i class="bi bi-shield-lock text-success"></i>
+          PKCE is enforced for all applications by the organization's
+          <strong>OAuth 2.1 strict mode</strong>
+          setting.
+        </div>
+      <% else %>
+        <div class="form-text">
+          PKCE prevents authorization code interception attacks. Recommended for SPAs and mobile apps.
+          <em>Automatically enabled for public clients.</em>
+        </div>
+      <% end %>
     </div>
     <%= for {msg, _} <- (Keyword.get_values(@changeset.errors, :require_pkce) || []) do %>
       <div class="invalid-feedback d-block">{msg}</div>

--- a/lib/authify_web/controllers/applications_html/edit.html.heex
+++ b/lib/authify_web/controllers/applications_html/edit.html.heex
@@ -33,6 +33,7 @@
             <.application_form
               changeset={@changeset}
               action={~p"/#{@current_organization.slug}/applications/#{@application}"}
+              org_strict_mode={@org_strict_mode}
             />
           </div>
         </div>

--- a/lib/authify_web/controllers/applications_html/new.html.heex
+++ b/lib/authify_web/controllers/applications_html/new.html.heex
@@ -33,6 +33,7 @@
             <.application_form
               changeset={@changeset}
               action={~p"/#{@current_organization.slug}/applications"}
+              org_strict_mode={@org_strict_mode}
             />
           </div>
         </div>

--- a/lib/authify_web/controllers/applications_html/show.html.heex
+++ b/lib/authify_web/controllers/applications_html/show.html.heex
@@ -109,17 +109,25 @@
             <div class="mb-3">
               <label class="form-label fw-bold">PKCE Required</label>
               <div class="bg-body-secondary p-3 rounded">
-                <%= if Authify.OAuth.Application.requires_pkce?(@application) do %>
-                  <span class="badge bg-success">
-                    <i class="bi bi-check-circle"></i> Yes
-                  </span>
-                  <%= if @application.client_type == "public" do %>
-                    <div class="small text-muted mt-1">Enforced for public clients</div>
-                  <% end %>
-                <% else %>
-                  <span class="badge bg-secondary">
-                    <i class="bi bi-dash-circle"></i> No
-                  </span>
+                <%= cond do %>
+                  <% @org_strict_mode -> %>
+                    <span class="badge bg-success">
+                      <i class="bi bi-check-circle"></i> Yes
+                    </span>
+                    <div class="small text-muted mt-1">
+                      Enforced by organization OAuth 2.1 strict mode
+                    </div>
+                  <% Authify.OAuth.Application.requires_pkce?(@application) -> %>
+                    <span class="badge bg-success">
+                      <i class="bi bi-check-circle"></i> Yes
+                    </span>
+                    <%= if @application.client_type == "public" do %>
+                      <div class="small text-muted mt-1">Enforced for public clients</div>
+                    <% end %>
+                  <% true -> %>
+                    <span class="badge bg-secondary">
+                      <i class="bi bi-dash-circle"></i> No
+                    </span>
                 <% end %>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Application show page previously displayed \"PKCE Required: No\" even when the org's OAuth 2.1 strict mode was enforcing PKCE for all clients
- New/edit form PKCE toggle was enabled and appeared settable, but had no effect under strict mode
- Now all three views correctly reflect the effective PKCE requirement, including its source

## Changes

- `ApplicationsController` — `show`, `new`, `edit`, and their error-path re-renders now compute and pass `org_strict_mode` via `Configurations.oauth_21_strict_mode?/1`
- `show.html.heex` — PKCE section uses `cond` to distinguish app-level vs org-level enforcement, showing an explanatory note for each case
- `application_form.html.heex` — PKCE toggle is checked and `disabled` when org strict mode is active, with a note replacing the default help text
- `new.html.heex` / `edit.html.heex` — pass `org_strict_mode` down to the shared form component

## Test plan

- [x] With org OAuth 2.1 strict mode **enabled**: application show page displays \"Yes — Enforced by organization OAuth 2.1 strict mode\"; edit/new form shows PKCE toggle checked and disabled
- [x] With org OAuth 2.1 strict mode **disabled** and app `require_pkce = true`: show page displays \"Yes\" with no org-level note; toggle is enabled and checked
- [x] With both disabled: show page displays \"No\"; toggle is enabled and unchecked

🤖 Generated with [Claude Code](https://claude.com/claude-code)