### PR TITLE
Password reset email link points to edit form route

### DIFF
--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -1744,7 +1744,7 @@ defmodule Authify.Accounts do
     domain = Authify.Organizations.get_email_link_domain(organization)
 
     # Build the reset URL with proper protocol/port for environment
-    "#{build_base_url(domain)}/password_reset/#{token}"
+    "#{build_base_url(domain)}/password_reset/#{token}/edit"
   end
 
   @doc """

--- a/test/authify/accounts_test.exs
+++ b/test/authify/accounts_test.exs
@@ -1068,6 +1068,14 @@ defmodule Authify.AccountsTest do
       refute String.contains?(token1, "/")
       refute String.contains?(token2, "/")
     end
+
+    test "build_password_reset_url/2 generates a link to the edit form" do
+      organization = organization_fixture()
+      token = User.generate_password_reset_token()
+      url = Accounts.build_password_reset_url(organization, token)
+
+      assert String.ends_with?(url, "/password_reset/#{token}/edit")
+    end
   end
 
   describe "certificates" do


### PR DESCRIPTION
Fixes #62

## Summary

- `build_password_reset_url/2` was generating `/password_reset/:token`, but no `GET` route exists for that path
- The reset form lives at `GET /password_reset/:token/edit` — clicking the email link produced a \"no route found\" error
- Added `/edit` to the generated URL so email links land on the correct route
- Added a test asserting the URL ends with `/password_reset/:token/edit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)