### PR TITLE
fix: WebAuthn Touch ID authentication fails with JSON parse error

### DIFF
--- a/lib/authify/mfa/webauthn.ex
+++ b/lib/authify/mfa/webauthn.ex
@@ -552,7 +552,11 @@ defmodule Authify.MFA.WebAuthn do
   defp verify_signature(credential, auth_data_binary, client_data_json_bytes, signature_b64) do
     case Encryption.decrypt(credential.public_key) do
       {:ok, public_key_cbor} ->
-        with {:ok, {cose_key, _}} <- CBOR.decode(public_key_cbor),
+        # Use Wax.Utils.CBOR.decode/1 instead of raw CBOR.decode/1 because:
+        # 1. It returns {:ok, value, rest} matching the actual CBOR library return format
+        # 2. It unwraps %CBOR.Tag{tag: :bytes} structs to plain binaries,
+        #    which Wax.CoseKey.verify requires for EC key coordinates
+        with {:ok, cose_key, _} <- Wax.Utils.CBOR.decode(public_key_cbor),
              {:ok, signature} <- Base.url_decode64(signature_b64, padding: false),
              client_data_hash = :crypto.hash(:sha256, client_data_json_bytes),
              verification_data = auth_data_binary <> client_data_hash,


### PR DESCRIPTION
Fixes #63

## Summary

- `verify_signature/4` matched `CBOR.decode/1`'s return value as `{:ok, {cose_key, _}}` (2-tuple), but the library actually returns `{:ok, value, rest}` (3-tuple)
- The unmatched `with` clause raised a `WithClauseError`, producing a 500 HTML response instead of JSON — which the JS client then failed to parse, surfacing as "JSON.parse: unexpected character at line 1 column 1"
- A second issue: raw `CBOR.decode/1` wraps byte values in `%CBOR.Tag{tag: :bytes}` structs, but `Wax.CoseKey.verify` requires plain binaries for EC key coordinates

Replaced `CBOR.decode/1` with `Wax.Utils.CBOR.decode/1`, which returns the correct 3-tuple format and recursively unwraps all `%CBOR.Tag{tag: :bytes}` values to plain binaries — exactly what `Wax.CoseKey` expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)