### PR TITLE
WebAuthn fails in production due to missing rpId configuration

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -129,6 +129,20 @@ if config_env() == :prod do
 
   config :authify, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  # ## WebAuthn Configuration
+  #
+  # The Relying Party ID must match the domain where Authify is hosted.
+  # Defaults to PHX_HOST if WEBAUTHN_RP_ID is not explicitly set.
+  # This MUST be set correctly or WebAuthn registration/authentication will fail
+  # with a "DOMException: The operation is insecure" browser error.
+  #
+  # Examples:
+  #   WEBAUTHN_RP_ID=authifyidp.com
+  #   WEBAUTHN_RP_ID=auth.example.com
+  webauthn_rp_id = System.get_env("WEBAUTHN_RP_ID") || host
+
+  config :authify, :webauthn_rp_id, webauthn_rp_id
+
   config :authify, AuthifyWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     http: [

--- a/lib/authify/mfa/webauthn.ex
+++ b/lib/authify/mfa/webauthn.ex
@@ -60,7 +60,7 @@ defmodule Authify.MFA.WebAuthn do
           challenge: challenge_b64,
           rp: %{
             name: get_rp_name(),
-            id: get_rp_id()
+            id: opts[:rp_id] || get_rp_id()
           },
           user: %{
             id: Base.url_encode64("user_#{user.id}", padding: false),
@@ -157,7 +157,7 @@ defmodule Authify.MFA.WebAuthn do
             challenge: challenge_b64,
             timeout: 60_000,
             # 60 seconds
-            rpId: get_rp_id(),
+            rpId: opts[:rp_id] || get_rp_id(),
             userVerification: opts[:user_verification] || "preferred",
             allowCredentials:
               Enum.map(credentials, fn cred ->

--- a/lib/authify/organizations.ex
+++ b/lib/authify/organizations.ex
@@ -103,6 +103,29 @@ defmodule Authify.Organizations do
   end
 
   @doc """
+  Resolves the WebAuthn Relying Party ID for an organization.
+
+  If the request host is a verified custom domain (CNAME) for the organization,
+  returns that domain as the rpId. Otherwise returns the globally configured
+  `:webauthn_rp_id` application setting (defaulting to "localhost").
+
+  This allows users on a custom domain to register and authenticate WebAuthn
+  credentials scoped to that domain.
+  """
+  def resolve_webauthn_rp_id(%Organization{} = org, request_host) do
+    OrganizationCname
+    |> where(
+      [c],
+      c.organization_id == ^org.id and c.domain == ^request_host and c.verified == true
+    )
+    |> Repo.one()
+    |> case do
+      nil -> Application.get_env(:authify, :webauthn_rp_id, "localhost")
+      _cname -> request_host
+    end
+  end
+
+  @doc """
   Gets the effective email link domain for an organization.
 
   Returns the configured email_link_domain if set, otherwise falls back

--- a/lib/authify_web/controllers/mfa_controller.ex
+++ b/lib/authify_web/controllers/mfa_controller.ex
@@ -3,7 +3,7 @@ defmodule AuthifyWeb.MfaController do
 
   import AuthifyWeb.Helpers.ConnHelpers, only: [get_client_ip: 1, get_user_agent: 1]
 
-  alias Authify.{Accounts, MFA, Repo}
+  alias Authify.{Accounts, MFA, Organizations, Repo}
   alias Authify.Accounts.User
   alias AuthifyWeb.Helpers.AuditHelper
 
@@ -324,11 +324,12 @@ defmodule AuthifyWeb.MfaController do
       {:error, _message} ->
         json(conn, %{success: false, error: "No active MFA session"})
 
-      {:ok, user, _organization} ->
+      {:ok, user, organization} ->
         # Get authentication options from WebAuthn context
         opts = [
           ip_address: get_client_ip(conn),
-          user_agent: get_user_agent(conn)
+          user_agent: get_user_agent(conn),
+          rp_id: Organizations.resolve_webauthn_rp_id(organization, conn.host)
         ]
 
         case MFA.WebAuthn.begin_authentication(user, opts) do

--- a/lib/authify_web/controllers/webauthn_controller.ex
+++ b/lib/authify_web/controllers/webauthn_controller.ex
@@ -11,7 +11,7 @@ defmodule AuthifyWeb.WebAuthnController do
 
   import AuthifyWeb.Helpers.ConnHelpers, only: [get_client_ip: 1, get_user_agent: 1]
 
-  alias Authify.{Accounts, MFA, Repo}
+  alias Authify.{Accounts, MFA, Organizations, Repo}
   alias Authify.Accounts.User
   alias Authify.MFA.WebAuthn
 
@@ -42,6 +42,7 @@ defmodule AuthifyWeb.WebAuthnController do
   """
   def register_begin(conn, params) do
     current_user = conn.assigns.current_user
+    organization = conn.assigns.current_organization
 
     # Extract options from params
     opts = [
@@ -50,7 +51,8 @@ defmodule AuthifyWeb.WebAuthnController do
       attestation: params["attestation"] || "none",
       credential_type: params["credentialType"],
       ip_address: get_client_ip(conn),
-      user_agent: get_user_agent(conn)
+      user_agent: get_user_agent(conn),
+      rp_id: Organizations.resolve_webauthn_rp_id(organization, conn.host)
     ]
 
     case WebAuthn.begin_registration(current_user, opts) do


### PR DESCRIPTION
## Summary

- WebAuthn registration was failing in production with `DOMException: The operation is insecure` because the server was sending `rpId: "localhost"` (the default) to the browser, which rejected it since it didn't match the production domain
- Added `WEBAUTHN_RP_ID` environment variable support in `runtime.exs`, defaulting to `PHX_HOST` so no extra configuration is needed in most deployments
- Added `Organizations.resolve_webauthn_rp_id/2` to support org custom domains: if the request arrives on a verified CNAME for the org, that domain is used as the rpId instead of the global config — enabling WebAuthn to work correctly for organizations using custom domains

## Test plan

- [ ] Deploy to production with `PHX_HOST=authifyidp.com` (or set `WEBAUTHN_RP_ID=authifyidp.com` explicitly) and verify TouchID/YubiKey registration succeeds
- [ ] Verify WebAuthn authentication (MFA step) also works end-to-end in production
- [ ] For custom domain orgs: verify that a user on a verified CNAME domain can register and authenticate WebAuthn credentials scoped to that domain
- [ ] Verify that an unverified CNAME is not used as rpId (falls back to global config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)