### PR TITLE
test: add unit tests for Group, GroupMembership, OAuth tokens, Encryption, Scopes, and UserEmail

### DIFF
--- a/test/authify/accounts/user_email_test.exs
+++ b/test/authify/accounts/user_email_test.exs
@@ -1,0 +1,181 @@
+defmodule Authify.Accounts.UserEmailTest do
+  @moduledoc false
+  use Authify.DataCase, async: true
+
+  alias Authify.Accounts.UserEmail
+
+  import Authify.AccountsFixtures
+
+  describe "changeset/2" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+      %{user: user}
+    end
+
+    test "valid with email address and user_id", %{user: user} do
+      changeset =
+        UserEmail.changeset(%UserEmail{}, %{value: "valid@example.com", user_id: user.id})
+
+      assert changeset.valid?
+    end
+
+    test "requires value", %{user: user} do
+      changeset = UserEmail.changeset(%UserEmail{}, %{user_id: user.id})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).value
+    end
+
+    test "requires user_id" do
+      changeset = UserEmail.changeset(%UserEmail{}, %{value: "valid@example.com"})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).user_id
+    end
+
+    test "rejects email missing @" do
+      changeset = UserEmail.changeset(%UserEmail{}, %{value: "notanemail", user_id: 1})
+      refute changeset.valid?
+      assert "has invalid format" in errors_on(changeset).value
+    end
+
+    test "rejects email missing domain extension" do
+      changeset = UserEmail.changeset(%UserEmail{}, %{value: "user@nodot", user_id: 1})
+      refute changeset.valid?
+      assert "has invalid format" in errors_on(changeset).value
+    end
+
+    test "rejects email with whitespace" do
+      changeset = UserEmail.changeset(%UserEmail{}, %{value: "user @example.com", user_id: 1})
+      refute changeset.valid?
+      assert "has invalid format" in errors_on(changeset).value
+    end
+
+    test "rejects email exceeding 160 characters", %{user: user} do
+      long_email = String.duplicate("a", 150) <> "@example.com"
+      changeset = UserEmail.changeset(%UserEmail{}, %{value: long_email, user_id: user.id})
+      refute changeset.valid?
+      assert "should be at most 160 character(s)" in errors_on(changeset).value
+    end
+
+    test "validates type inclusion - accepts work, home, other", %{user: user} do
+      for type <- ["work", "home", "other"] do
+        changeset =
+          UserEmail.changeset(%UserEmail{}, %{
+            value: "test@example.com",
+            user_id: user.id,
+            type: type
+          })
+
+        assert changeset.valid?, "expected type #{type} to be valid"
+      end
+    end
+
+    test "rejects invalid type", %{user: user} do
+      changeset =
+        UserEmail.changeset(%UserEmail{}, %{
+          value: "test@example.com",
+          user_id: user.id,
+          type: "personal"
+        })
+
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).type
+    end
+
+    test "defaults type to work when not specified", %{user: user} do
+      changeset =
+        UserEmail.changeset(%UserEmail{}, %{value: "test@example.com", user_id: user.id})
+
+      # Default is set on the schema, not the changeset change
+      assert Ecto.Changeset.get_field(changeset, :type) == "work"
+    end
+  end
+
+  describe "nested_changeset/2" do
+    test "valid without user_id" do
+      changeset = UserEmail.nested_changeset(%UserEmail{}, %{value: "nested@example.com"})
+      assert changeset.valid?
+    end
+
+    test "requires value" do
+      changeset = UserEmail.nested_changeset(%UserEmail{}, %{})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).value
+    end
+
+    test "rejects invalid email format" do
+      changeset = UserEmail.nested_changeset(%UserEmail{}, %{value: "not-an-email"})
+      refute changeset.valid?
+      assert "has invalid format" in errors_on(changeset).value
+    end
+
+    test "validates type inclusion" do
+      changeset =
+        UserEmail.nested_changeset(%UserEmail{}, %{value: "test@example.com", type: "invalid"})
+
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).type
+    end
+  end
+
+  describe "verify_changeset/1" do
+    test "sets verified_at to a current timestamp" do
+      email = %UserEmail{
+        verification_token: "some_token",
+        verification_expires_at: DateTime.utc_now()
+      }
+
+      changeset = UserEmail.verify_changeset(email)
+      verified_at = Ecto.Changeset.get_change(changeset, :verified_at)
+      assert %DateTime{} = verified_at
+      assert DateTime.diff(DateTime.utc_now(), verified_at, :second) < 2
+    end
+
+    test "clears the verification_token" do
+      email = %UserEmail{verification_token: "some_hashed_token"}
+      changeset = UserEmail.verify_changeset(email)
+      assert Ecto.Changeset.get_change(changeset, :verification_token) == nil
+    end
+
+    test "clears the verification_expires_at" do
+      email = %UserEmail{
+        verification_expires_at: DateTime.utc_now() |> DateTime.add(3600, :second)
+      }
+
+      changeset = UserEmail.verify_changeset(email)
+      assert Ecto.Changeset.get_change(changeset, :verification_expires_at) == nil
+    end
+  end
+
+  describe "verification_token_changeset/2" do
+    test "stores a SHA-256 hash of the token (not the plaintext)" do
+      email = %UserEmail{}
+      plaintext_token = "my_verification_token"
+      changeset = UserEmail.verification_token_changeset(email, plaintext_token)
+
+      stored_token = Ecto.Changeset.get_change(changeset, :verification_token)
+      expected_hash = :crypto.hash(:sha256, plaintext_token) |> Base.encode16(case: :lower)
+
+      assert stored_token == expected_hash
+      refute stored_token == plaintext_token
+    end
+
+    test "sets verification_expires_at approximately 24 hours from now" do
+      changeset = UserEmail.verification_token_changeset(%UserEmail{}, "some_token")
+      expires_at = Ecto.Changeset.get_change(changeset, :verification_expires_at)
+      assert %DateTime{} = expires_at
+      diff = DateTime.diff(expires_at, DateTime.utc_now(), :second)
+      assert diff > 24 * 3600 - 5
+      assert diff <= 24 * 3600
+    end
+
+    test "different tokens produce different stored hashes" do
+      cs1 = UserEmail.verification_token_changeset(%UserEmail{}, "token_one")
+      cs2 = UserEmail.verification_token_changeset(%UserEmail{}, "token_two")
+
+      hash1 = Ecto.Changeset.get_change(cs1, :verification_token)
+      hash2 = Ecto.Changeset.get_change(cs2, :verification_token)
+      refute hash1 == hash2
+    end
+  end
+end

--- a/test/authify/accounts_test.exs
+++ b/test/authify/accounts_test.exs
@@ -2,7 +2,7 @@ defmodule Authify.AccountsTest do
   use Authify.DataCase, async: true
 
   alias Authify.Accounts
-  alias Authify.Accounts.{Invitation, Organization, User}
+  alias Authify.Accounts.{Group, GroupMembership, Invitation, Organization, User}
 
   import Authify.AccountsFixtures
 
@@ -1274,6 +1274,516 @@ defmodule Authify.AccountsTest do
 
       assert {:ok, cert} = Accounts.get_or_generate_oauth_signing_certificate(organization)
       assert cert.id == existing.id
+    end
+  end
+
+  describe "groups" do
+    setup do
+      {:ok, org} = Accounts.create_organization(valid_org_attrs())
+      %{organization: org}
+    end
+
+    test "Group.changeset/2 with valid attrs produces a valid changeset", %{organization: org} do
+      changeset =
+        Group.changeset(%Group{}, %{"name" => "Engineering", "organization_id" => org.id})
+
+      assert changeset.valid?
+    end
+
+    test "Group.changeset/2 requires name", %{organization: org} do
+      changeset = Group.changeset(%Group{}, %{"organization_id" => org.id})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).name
+    end
+
+    test "Group.changeset/2 requires organization_id" do
+      changeset = Group.changeset(%Group{}, %{"name" => "Engineering"})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).organization_id
+    end
+
+    test "Group.changeset/2 validates name max length", %{organization: org} do
+      changeset =
+        Group.changeset(%Group{}, %{
+          "name" => String.duplicate("a", 256),
+          "organization_id" => org.id
+        })
+
+      refute changeset.valid?
+      assert "should be at most 255 character(s)" in errors_on(changeset).name
+    end
+
+    test "Group.changeset/2 validates description max length", %{organization: org} do
+      changeset =
+        Group.changeset(%Group{}, %{
+          "name" => "Engineering",
+          "organization_id" => org.id,
+          "description" => String.duplicate("a", 1001)
+        })
+
+      refute changeset.valid?
+      assert "should be at most 1000 character(s)" in errors_on(changeset).description
+    end
+
+    test "Group.changeset/2 accepts valid external_id", %{organization: org} do
+      changeset =
+        Group.changeset(%Group{}, %{
+          "name" => "Engineering",
+          "organization_id" => org.id,
+          "external_id" => "ext-123.valid_id"
+        })
+
+      assert changeset.valid?
+    end
+
+    test "Group.changeset/2 rejects external_id starting with non-alphanumeric character", %{
+      organization: org
+    } do
+      changeset =
+        Group.changeset(%Group{}, %{
+          "name" => "Engineering",
+          "organization_id" => org.id,
+          "external_id" => "-bad-start"
+        })
+
+      refute changeset.valid?
+      assert Enum.any?(errors_on(changeset).external_id, &String.contains?(&1, "must start with"))
+    end
+
+    test "Group.changeset/2 rejects external_id exceeding max length", %{organization: org} do
+      changeset =
+        Group.changeset(%Group{}, %{
+          "name" => "Engineering",
+          "organization_id" => org.id,
+          "external_id" => "a" <> String.duplicate("x", 255)
+        })
+
+      refute changeset.valid?
+      assert "should be at most 255 character(s)" in errors_on(changeset).external_id
+    end
+
+    test "create_group/1 defaults is_active to true", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{"name" => "Default Active", "organization_id" => org.id})
+
+      assert group.is_active == true
+    end
+
+    test "create_group/1 allows setting is_active to false", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{
+          "name" => "Inactive Group",
+          "organization_id" => org.id,
+          "is_active" => false
+        })
+
+      assert group.is_active == false
+    end
+
+    test "Group.apply_scim_timestamps/2 sets scim timestamps on insert", %{organization: org} do
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      {:ok, group} =
+        Accounts.create_group(%{
+          name: "SCIM Group",
+          organization_id: org.id,
+          scim_created_at: now,
+          scim_updated_at: now
+        })
+
+      assert group.scim_created_at == now
+      assert group.scim_updated_at == now
+    end
+
+    test "list_groups/1 returns all groups for the organization", %{organization: org} do
+      {:ok, g1} = Accounts.create_group(%{"name" => "Alpha", "organization_id" => org.id})
+      {:ok, g2} = Accounts.create_group(%{"name" => "Beta", "organization_id" => org.id})
+      ids = Accounts.list_groups(org) |> Enum.map(& &1.id)
+      assert g1.id in ids
+      assert g2.id in ids
+    end
+
+    test "list_groups/1 does not return groups from other organizations", %{organization: org} do
+      {:ok, other_org} = Accounts.create_organization(valid_org_attrs())
+
+      {:ok, other_group} =
+        Accounts.create_group(%{"name" => "Other", "organization_id" => other_org.id})
+
+      ids = Accounts.list_groups(org) |> Enum.map(& &1.id)
+      refute other_group.id in ids
+    end
+
+    test "list_groups_filtered/2 with no opts returns all groups", %{organization: org} do
+      {:ok, g1} = Accounts.create_group(%{"name" => "Gamma", "organization_id" => org.id})
+      ids = Accounts.list_groups_filtered(org) |> Enum.map(& &1.id)
+      assert g1.id in ids
+    end
+
+    test "list_groups_filtered/2 filters by active status true", %{organization: org} do
+      {:ok, active} =
+        Accounts.create_group(%{
+          "name" => "Active",
+          "organization_id" => org.id,
+          "is_active" => true
+        })
+
+      {:ok, inactive} =
+        Accounts.create_group(%{
+          "name" => "Inactive",
+          "organization_id" => org.id,
+          "is_active" => false
+        })
+
+      results = Accounts.list_groups_filtered(org, status: true)
+      ids = Enum.map(results, & &1.id)
+      assert active.id in ids
+      refute inactive.id in ids
+    end
+
+    test "list_groups_filtered/2 filters by active status false", %{organization: org} do
+      {:ok, active} =
+        Accounts.create_group(%{
+          "name" => "Active2",
+          "organization_id" => org.id,
+          "is_active" => true
+        })
+
+      {:ok, inactive} =
+        Accounts.create_group(%{
+          "name" => "Inactive2",
+          "organization_id" => org.id,
+          "is_active" => false
+        })
+
+      results = Accounts.list_groups_filtered(org, status: false)
+      ids = Enum.map(results, & &1.id)
+      assert inactive.id in ids
+      refute active.id in ids
+    end
+
+    test "list_groups_filtered/2 searches by name", %{organization: org} do
+      {:ok, match} =
+        Accounts.create_group(%{"name" => "UniqueSearchName", "organization_id" => org.id})
+
+      {:ok, no_match} =
+        Accounts.create_group(%{"name" => "SomethingElse", "organization_id" => org.id})
+
+      results = Accounts.list_groups_filtered(org, search: "UniqueSearchName")
+      ids = Enum.map(results, & &1.id)
+      assert match.id in ids
+      refute no_match.id in ids
+    end
+
+    test "list_groups_filtered/2 searches by description", %{organization: org} do
+      {:ok, match} =
+        Accounts.create_group(%{
+          "name" => "GroupWithDesc",
+          "organization_id" => org.id,
+          "description" => "UniqueDescriptionText"
+        })
+
+      {:ok, no_match} =
+        Accounts.create_group(%{"name" => "NoDescGroup", "organization_id" => org.id})
+
+      results = Accounts.list_groups_filtered(org, search: "UniqueDescriptionText")
+      ids = Enum.map(results, & &1.id)
+      assert match.id in ids
+      refute no_match.id in ids
+    end
+
+    test "list_groups_filtered/2 sorts by name ascending", %{organization: org} do
+      Accounts.create_group(%{"name" => "Zephyr", "organization_id" => org.id})
+      Accounts.create_group(%{"name" => "Aardvark", "organization_id" => org.id})
+      results = Accounts.list_groups_filtered(org, sort: :name, order: :asc)
+      names = Enum.map(results, & &1.name)
+      assert names == Enum.sort(names)
+    end
+
+    test "list_groups_filtered/2 sorts by name descending", %{organization: org} do
+      Accounts.create_group(%{"name" => "Zeta", "organization_id" => org.id})
+      Accounts.create_group(%{"name" => "Alpha", "organization_id" => org.id})
+      results = Accounts.list_groups_filtered(org, sort: :name, order: :desc)
+      names = Enum.map(results, & &1.name)
+      assert names == Enum.sort(names, :desc)
+    end
+
+    test "get_group!/2 returns the group scoped to the organization", %{organization: org} do
+      {:ok, group} = Accounts.create_group(%{"name" => "GetTest", "organization_id" => org.id})
+      found = Accounts.get_group!(group.id, org)
+      assert found.id == group.id
+      assert found.name == "GetTest"
+    end
+
+    test "get_group!/2 raises when group belongs to a different organization", %{
+      organization: org
+    } do
+      {:ok, other_org} = Accounts.create_organization(valid_org_attrs())
+
+      {:ok, group} =
+        Accounts.create_group(%{"name" => "OtherOrgGroup", "organization_id" => other_org.id})
+
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_group!(group.id, org) end
+    end
+
+    test "get_group/1 returns group by integer id", %{organization: org} do
+      {:ok, group} = Accounts.create_group(%{"name" => "IntIdGroup", "organization_id" => org.id})
+      found = Accounts.get_group(group.id)
+      assert found.id == group.id
+    end
+
+    test "get_group/1 returns group by string id", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{"name" => "StringIdGroup", "organization_id" => org.id})
+
+      found = Accounts.get_group(Integer.to_string(group.id))
+      assert found.id == group.id
+    end
+
+    test "get_group/1 returns nil for non-existent integer id" do
+      assert Accounts.get_group(999_999_999) == nil
+    end
+
+    test "get_group/1 returns nil for non-numeric string id" do
+      assert Accounts.get_group("not-a-number") == nil
+    end
+
+    test "create_group/1 with valid attrs creates a group", %{organization: org} do
+      assert {:ok, %Group{} = group} =
+               Accounts.create_group(%{
+                 "name" => "New Group",
+                 "organization_id" => org.id,
+                 "description" => "A test group"
+               })
+
+      assert group.name == "New Group"
+      assert group.description == "A test group"
+      assert group.organization_id == org.id
+      assert group.is_active == true
+    end
+
+    test "create_group/1 with invalid attrs returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Accounts.create_group(%{"name" => ""})
+    end
+
+    test "create_group/1 enforces unique name within the same organization", %{organization: org} do
+      {:ok, _} = Accounts.create_group(%{"name" => "DupeName", "organization_id" => org.id})
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Accounts.create_group(%{"name" => "DupeName", "organization_id" => org.id})
+
+      assert "Group name already exists in this organization" in errors_on(changeset).name
+    end
+
+    test "create_group/1 allows the same name across different organizations", %{
+      organization: org
+    } do
+      {:ok, other_org} = Accounts.create_organization(valid_org_attrs())
+      {:ok, _} = Accounts.create_group(%{"name" => "SharedName", "organization_id" => org.id})
+
+      assert {:ok, _} =
+               Accounts.create_group(%{"name" => "SharedName", "organization_id" => other_org.id})
+    end
+
+    test "create_group/1 enforces unique external_id within the same organization", %{
+      organization: org
+    } do
+      {:ok, _} =
+        Accounts.create_group(%{
+          "name" => "Group1",
+          "organization_id" => org.id,
+          "external_id" => "ext-unique-123"
+        })
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Accounts.create_group(%{
+                 "name" => "Group2",
+                 "organization_id" => org.id,
+                 "external_id" => "ext-unique-123"
+               })
+
+      assert "external_id already exists in this organization" in errors_on(changeset).external_id
+    end
+
+    test "update_group/2 with valid attrs updates the group", %{organization: org} do
+      {:ok, group} = Accounts.create_group(%{"name" => "Before", "organization_id" => org.id})
+
+      assert {:ok, updated} =
+               Accounts.update_group(group, %{"name" => "After", "description" => "Updated"})
+
+      assert updated.name == "After"
+      assert updated.description == "Updated"
+    end
+
+    test "update_group/2 with invalid attrs returns error changeset", %{organization: org} do
+      {:ok, group} = Accounts.create_group(%{"name" => "Valid", "organization_id" => org.id})
+      assert {:error, %Ecto.Changeset{}} = Accounts.update_group(group, %{"name" => ""})
+    end
+
+    test "update_group/2 prevents changing external_id once set", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{
+          "name" => "ExtGroup",
+          "organization_id" => org.id,
+          "external_id" => "original-ext"
+        })
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Accounts.update_group(group, %{"external_id" => "changed-ext"})
+
+      assert "cannot be changed once set" in errors_on(changeset).external_id
+    end
+
+    test "update_group/2 allows setting the same external_id value again", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{
+          "name" => "SameExtGroup",
+          "organization_id" => org.id,
+          "external_id" => "keep-same"
+        })
+
+      assert {:ok, updated} =
+               Accounts.update_group(group, %{
+                 "external_id" => "keep-same",
+                 "name" => "Updated Name"
+               })
+
+      assert updated.external_id == "keep-same"
+      assert updated.name == "Updated Name"
+    end
+
+    test "delete_group/1 deletes the group", %{organization: org} do
+      {:ok, group} = Accounts.create_group(%{"name" => "ToDelete", "organization_id" => org.id})
+      assert {:ok, %Group{}} = Accounts.delete_group(group)
+      assert_raise Ecto.NoResultsError, fn -> Accounts.get_group!(group.id, org) end
+    end
+
+    test "change_group/2 returns a group changeset", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{"name" => "ForChangeset", "organization_id" => org.id})
+
+      assert %Ecto.Changeset{} = Accounts.change_group(group)
+    end
+
+    test "get_group_by_external_id/2 finds group by external_id", %{organization: org} do
+      {:ok, group} =
+        Accounts.create_group(%{
+          "name" => "ExtLookup",
+          "organization_id" => org.id,
+          "external_id" => "lookup-ext-id"
+        })
+
+      found = Accounts.get_group_by_external_id("lookup-ext-id", org.id)
+      assert found.id == group.id
+    end
+
+    test "get_group_by_external_id/2 returns nil when not found", %{organization: org} do
+      assert Accounts.get_group_by_external_id("nonexistent", org.id) == nil
+    end
+
+    test "get_group_by_external_id/2 returns nil for nil arguments" do
+      assert Accounts.get_group_by_external_id(nil, nil) == nil
+    end
+  end
+
+  describe "group memberships" do
+    setup do
+      {:ok, org} = Accounts.create_organization(valid_org_attrs())
+      {:ok, user} = Accounts.create_user_with_role(valid_user_attrs(), org.id, "user")
+
+      {:ok, group} =
+        Accounts.create_group(%{"name" => "MembershipGroup", "organization_id" => org.id})
+
+      %{organization: org, user: user, group: group}
+    end
+
+    test "GroupMembership.changeset/2 with valid attrs produces a valid changeset", %{
+      user: user,
+      group: group
+    } do
+      changeset =
+        GroupMembership.changeset(%GroupMembership{}, %{user_id: user.id, group_id: group.id})
+
+      assert changeset.valid?
+    end
+
+    test "GroupMembership.changeset/2 requires user_id", %{group: group} do
+      changeset = GroupMembership.changeset(%GroupMembership{}, %{group_id: group.id})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).user_id
+    end
+
+    test "GroupMembership.changeset/2 requires group_id", %{user: user} do
+      changeset = GroupMembership.changeset(%GroupMembership{}, %{user_id: user.id})
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).group_id
+    end
+
+    test "add_user_to_group/2 adds the user to the group", %{user: user, group: group} do
+      assert {:ok, %GroupMembership{}} = Accounts.add_user_to_group(user, group)
+      members = Accounts.list_group_members(group)
+      assert Enum.any?(members, &(&1.id == user.id))
+    end
+
+    test "add_user_to_group/2 returns error when user is already in the group", %{
+      user: user,
+      group: group
+    } do
+      {:ok, _} = Accounts.add_user_to_group(user, group)
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Accounts.add_user_to_group(user, group)
+      assert "User is already in this group" in errors_on(changeset).user_id
+    end
+
+    test "remove_user_from_group/2 removes the user from the group", %{user: user, group: group} do
+      {:ok, _} = Accounts.add_user_to_group(user, group)
+      Accounts.remove_user_from_group(user, group)
+      members = Accounts.list_group_members(group)
+      refute Enum.any?(members, &(&1.id == user.id))
+    end
+
+    test "list_group_members/1 returns all users in the group", %{
+      organization: org,
+      group: group
+    } do
+      {:ok, user2} = Accounts.create_user_with_role(valid_user_attrs(), org.id, "user")
+      {:ok, user3} = Accounts.create_user_with_role(valid_user_attrs(), org.id, "user")
+      {:ok, _} = Accounts.add_user_to_group(user2, group)
+      {:ok, _} = Accounts.add_user_to_group(user3, group)
+
+      ids = Accounts.list_group_members(group) |> Enum.map(& &1.id)
+      assert user2.id in ids
+      assert user3.id in ids
+    end
+
+    test "list_group_members/1 returns empty list when group has no members", %{group: group} do
+      assert Accounts.list_group_members(group) == []
+    end
+
+    test "list_user_groups/1 returns all groups the user belongs to", %{
+      organization: org,
+      user: user
+    } do
+      {:ok, group2} =
+        Accounts.create_group(%{"name" => "SecondGroup", "organization_id" => org.id})
+
+      {:ok, _other} =
+        Accounts.create_group(%{"name" => "NotJoined", "organization_id" => org.id})
+
+      {:ok, _} = Accounts.add_user_to_group(user, group2)
+
+      group_ids = Accounts.list_user_groups(user) |> Enum.map(& &1.id)
+      assert group2.id in group_ids
+    end
+
+    test "list_user_groups/1 returns empty list when user belongs to no groups", %{user: user} do
+      assert Accounts.list_user_groups(user) == []
+    end
+
+    test "delete_group/1 cascades to remove group memberships", %{user: user, group: group} do
+      {:ok, _} = Accounts.add_user_to_group(user, group)
+      {:ok, _} = Accounts.delete_group(group)
+      group_ids = Accounts.list_user_groups(user) |> Enum.map(& &1.id)
+      refute group.id in group_ids
     end
   end
 end

--- a/test/authify/encryption_test.exs
+++ b/test/authify/encryption_test.exs
@@ -1,0 +1,90 @@
+defmodule Authify.EncryptionTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Authify.Encryption
+
+  describe "encrypt_with_password/2 and decrypt_with_password/2" do
+    test "roundtrip: decrypting an encrypted value returns the original" do
+      password = "test_password_123"
+      plaintext = "sensitive data to protect"
+
+      encrypted = Encryption.encrypt_with_password(plaintext, password)
+      assert is_binary(encrypted)
+      assert {:ok, ^plaintext} = Encryption.decrypt_with_password(encrypted, password)
+    end
+
+    test "encrypts empty string" do
+      password = "test_password"
+      encrypted = Encryption.encrypt_with_password("", password)
+      assert is_binary(encrypted)
+      assert {:ok, ""} = Encryption.decrypt_with_password(encrypted, password)
+    end
+
+    test "encrypts binary data with special characters" do
+      password = "test_password"
+      plaintext = "data with special chars: \n\t\0 unicode: 日本語"
+      encrypted = Encryption.encrypt_with_password(plaintext, password)
+      assert {:ok, ^plaintext} = Encryption.decrypt_with_password(encrypted, password)
+    end
+
+    test "produces different ciphertext for the same plaintext each time (random IV/salt)" do
+      password = "test_password"
+      plaintext = "same plaintext"
+      encrypted1 = Encryption.encrypt_with_password(plaintext, password)
+      encrypted2 = Encryption.encrypt_with_password(plaintext, password)
+      refute encrypted1 == encrypted2
+    end
+
+    test "encrypted output is base64-encoded" do
+      encrypted = Encryption.encrypt_with_password("test", "password")
+      assert String.match?(encrypted, ~r/^[A-Za-z0-9+\/]+=*$/)
+    end
+
+    test "decryption with wrong password returns an error" do
+      encrypted = Encryption.encrypt_with_password("secret", "correct_password")
+      assert {:error, _reason} = Encryption.decrypt_with_password(encrypted, "wrong_password")
+    end
+
+    test "decryption of corrupted data returns an error" do
+      password = "test_password"
+      encrypted = Encryption.encrypt_with_password("secret", password)
+
+      # Corrupt one byte in the ciphertext portion (after 48-byte salt+iv+tag prefix)
+      corrupted =
+        encrypted
+        |> Base.decode64!()
+        |> then(fn <<prefix::binary-size(48), byte::size(8), rest::binary>> ->
+          <<prefix::binary, rem(byte + 1, 256)::size(8), rest::binary>>
+        end)
+        |> Base.encode64()
+
+      assert {:error, _reason} = Encryption.decrypt_with_password(corrupted, password)
+    end
+  end
+
+  describe "encrypt/1 and decrypt/1" do
+    test "roundtrip using the application encryption password" do
+      plaintext = "application-level secret"
+      encrypted = Encryption.encrypt(plaintext)
+      assert is_binary(encrypted)
+      assert {:ok, ^plaintext} = Encryption.decrypt(encrypted)
+    end
+
+    test "encrypt returns a different ciphertext each call" do
+      plaintext = "same value"
+      enc1 = Encryption.encrypt(plaintext)
+      enc2 = Encryption.encrypt(plaintext)
+      refute enc1 == enc2
+    end
+
+    test "decrypt returns {:ok, value} on success" do
+      encrypted = Encryption.encrypt("hello")
+      assert {:ok, "hello"} = Encryption.decrypt(encrypted)
+    end
+
+    test "decrypt returns {:error, reason} on invalid input" do
+      assert {:error, _} = Encryption.decrypt("not_valid_base64!!!")
+    end
+  end
+end

--- a/test/authify/o_auth/access_token_test.exs
+++ b/test/authify/o_auth/access_token_test.exs
@@ -1,0 +1,201 @@
+defmodule Authify.OAuth.AccessTokenTest do
+  @moduledoc false
+  use Authify.DataCase, async: true
+
+  alias Authify.OAuth.AccessToken
+
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
+  describe "changeset/2" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+      app = application_fixture(organization: org)
+      %{user: user, app: app}
+    end
+
+    test "valid changeset with required fields", %{user: user, app: app} do
+      attrs = %{scopes: "openid profile", application_id: app.id, user_id: user.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "requires scopes", %{user: user, app: app} do
+      attrs = %{application_id: app.id, user_id: user.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).scopes
+    end
+
+    test "requires application_id", %{user: user} do
+      attrs = %{scopes: "openid", user_id: user.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).application_id
+    end
+
+    test "requires user_id", %{app: app} do
+      attrs = %{scopes: "openid", application_id: app.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).user_id
+    end
+
+    test "auto-generates a token", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      assert changeset.valid?
+      token = Ecto.Changeset.get_change(changeset, :token)
+      assert is_binary(token)
+      assert byte_size(token) > 0
+    end
+
+    test "generates a different token on each call", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      cs1 = AccessToken.changeset(%AccessToken{}, attrs)
+      cs2 = AccessToken.changeset(%AccessToken{}, attrs)
+      refute Ecto.Changeset.get_change(cs1, :token) == Ecto.Changeset.get_change(cs2, :token)
+    end
+
+    test "auto-generates expires_at approximately 1 hour from now", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = AccessToken.changeset(%AccessToken{}, attrs)
+      expires_at = Ecto.Changeset.get_change(changeset, :expires_at)
+      assert %DateTime{} = expires_at
+      diff = DateTime.diff(expires_at, DateTime.utc_now(), :second)
+      assert diff > 3600 - 5
+      assert diff <= 3600
+    end
+  end
+
+  describe "management_api_changeset/2" do
+    setup do
+      org = organization_fixture()
+      app = management_api_application_fixture(organization: org)
+      %{app: app}
+    end
+
+    test "valid without user_id", %{app: app} do
+      attrs = %{scopes: "users:read", application_id: app.id}
+      changeset = AccessToken.management_api_changeset(%AccessToken{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "requires scopes", %{app: app} do
+      attrs = %{application_id: app.id}
+      changeset = AccessToken.management_api_changeset(%AccessToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).scopes
+    end
+
+    test "requires application_id" do
+      attrs = %{scopes: "users:read"}
+      changeset = AccessToken.management_api_changeset(%AccessToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).application_id
+    end
+
+    test "auto-generates token and expires_at", %{app: app} do
+      attrs = %{scopes: "users:read", application_id: app.id}
+      changeset = AccessToken.management_api_changeset(%AccessToken{}, attrs)
+      assert changeset.valid?
+      assert is_binary(Ecto.Changeset.get_change(changeset, :token))
+      assert %DateTime{} = Ecto.Changeset.get_change(changeset, :expires_at)
+    end
+  end
+
+  describe "expired?/1" do
+    test "returns false when expires_at is in the future" do
+      token = %AccessToken{expires_at: DateTime.utc_now() |> DateTime.add(3600, :second)}
+      refute AccessToken.expired?(token)
+    end
+
+    test "returns true when expires_at is in the past" do
+      token = %AccessToken{expires_at: DateTime.utc_now() |> DateTime.add(-1, :second)}
+      assert AccessToken.expired?(token)
+    end
+  end
+
+  describe "revoked?/1" do
+    test "returns false when revoked_at is nil" do
+      token = %AccessToken{revoked_at: nil}
+      refute AccessToken.revoked?(token)
+    end
+
+    test "returns true when revoked_at is set" do
+      token = %AccessToken{revoked_at: DateTime.utc_now()}
+      assert AccessToken.revoked?(token)
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true when not expired and not revoked" do
+      token = %AccessToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(3600, :second),
+        revoked_at: nil
+      }
+
+      assert AccessToken.valid?(token)
+    end
+
+    test "returns false when expired" do
+      token = %AccessToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        revoked_at: nil
+      }
+
+      refute AccessToken.valid?(token)
+    end
+
+    test "returns false when revoked" do
+      token = %AccessToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(3600, :second),
+        revoked_at: DateTime.utc_now()
+      }
+
+      refute AccessToken.valid?(token)
+    end
+
+    test "returns false when both expired and revoked" do
+      token = %AccessToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        revoked_at: DateTime.utc_now()
+      }
+
+      refute AccessToken.valid?(token)
+    end
+  end
+
+  describe "revoke/1" do
+    test "puts a revoked_at timestamp on the changeset" do
+      changeset = Ecto.Changeset.change(%AccessToken{})
+      result = AccessToken.revoke(changeset)
+      assert %DateTime{} = Ecto.Changeset.get_change(result, :revoked_at)
+    end
+  end
+
+  describe "scopes_list/1" do
+    test "splits space-separated scopes into a list" do
+      token = %AccessToken{scopes: "openid profile email"}
+      assert AccessToken.scopes_list(token) == ["openid", "profile", "email"]
+    end
+
+    test "returns a single-element list for a single scope" do
+      token = %AccessToken{scopes: "openid"}
+      assert AccessToken.scopes_list(token) == ["openid"]
+    end
+
+    test "returns empty list when scopes is nil" do
+      assert AccessToken.scopes_list(%AccessToken{scopes: nil}) == []
+    end
+
+    test "ignores extra spaces between scopes" do
+      token = %AccessToken{scopes: " openid  profile "}
+      result = AccessToken.scopes_list(token)
+      assert "openid" in result
+      assert "profile" in result
+      refute "" in result
+    end
+  end
+end

--- a/test/authify/o_auth/authorization_code_test.exs
+++ b/test/authify/o_auth/authorization_code_test.exs
@@ -1,0 +1,315 @@
+defmodule Authify.OAuth.AuthorizationCodeTest do
+  @moduledoc false
+  use Authify.DataCase, async: true
+
+  alias Authify.OAuth.AuthorizationCode
+
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
+  describe "changeset/2" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+      app = application_fixture(organization: org)
+      %{user: user, app: app}
+    end
+
+    test "valid changeset without PKCE", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid profile",
+        application_id: app.id,
+        user_id: user.id
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "requires redirect_uri", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).redirect_uri
+    end
+
+    test "requires scopes", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        application_id: app.id,
+        user_id: user.id
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).scopes
+    end
+
+    test "requires application_id", %{user: user} do
+      attrs = %{redirect_uri: "https://example.com/callback", scopes: "openid", user_id: user.id}
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).application_id
+    end
+
+    test "requires user_id", %{app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).user_id
+    end
+
+    test "auto-generates a code", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      assert changeset.valid?
+      code = Ecto.Changeset.get_change(changeset, :code)
+      assert is_binary(code)
+      assert byte_size(code) > 0
+    end
+
+    test "auto-generates expires_at approximately 10 minutes from now", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      expires_at = Ecto.Changeset.get_change(changeset, :expires_at)
+      assert %DateTime{} = expires_at
+      diff = DateTime.diff(expires_at, DateTime.utc_now(), :second)
+      assert diff > 600 - 5
+      assert diff <= 600
+    end
+
+    test "accepts S256 PKCE", %{user: user, app: app} do
+      verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+
+      challenge =
+        :crypto.hash(:sha256, verifier)
+        |> Base.url_encode64(padding: false)
+
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id,
+        code_challenge: challenge,
+        code_challenge_method: "S256"
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "accepts plain PKCE", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id,
+        code_challenge: "my_plain_verifier",
+        code_challenge_method: "plain"
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "defaults code_challenge_method to plain when only challenge is provided", %{
+      user: user,
+      app: app
+    } do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id,
+        code_challenge: "my_challenge"
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :code_challenge_method) == "plain"
+    end
+
+    test "rejects invalid code_challenge_method", %{user: user, app: app} do
+      attrs = %{
+        redirect_uri: "https://example.com/callback",
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id,
+        code_challenge: "some_challenge",
+        code_challenge_method: "RS256"
+      }
+
+      changeset = AuthorizationCode.changeset(%AuthorizationCode{}, attrs)
+      refute changeset.valid?
+      assert "must be S256 or plain" in errors_on(changeset).code_challenge_method
+    end
+  end
+
+  describe "expired?/1" do
+    test "returns false when expires_at is in the future" do
+      code = %AuthorizationCode{expires_at: DateTime.utc_now() |> DateTime.add(600, :second)}
+      refute AuthorizationCode.expired?(code)
+    end
+
+    test "returns true when expires_at is in the past" do
+      code = %AuthorizationCode{expires_at: DateTime.utc_now() |> DateTime.add(-1, :second)}
+      assert AuthorizationCode.expired?(code)
+    end
+  end
+
+  describe "used?/1" do
+    test "returns false when used_at is nil" do
+      code = %AuthorizationCode{used_at: nil}
+      refute AuthorizationCode.used?(code)
+    end
+
+    test "returns true when used_at is set" do
+      code = %AuthorizationCode{used_at: DateTime.utc_now()}
+      assert AuthorizationCode.used?(code)
+    end
+  end
+
+  describe "valid_for_exchange?/1" do
+    test "returns true when not expired and not used" do
+      code = %AuthorizationCode{
+        expires_at: DateTime.utc_now() |> DateTime.add(600, :second),
+        used_at: nil
+      }
+
+      assert AuthorizationCode.valid_for_exchange?(code)
+    end
+
+    test "returns false when expired" do
+      code = %AuthorizationCode{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        used_at: nil
+      }
+
+      refute AuthorizationCode.valid_for_exchange?(code)
+    end
+
+    test "returns false when already used" do
+      code = %AuthorizationCode{
+        expires_at: DateTime.utc_now() |> DateTime.add(600, :second),
+        used_at: DateTime.utc_now()
+      }
+
+      refute AuthorizationCode.valid_for_exchange?(code)
+    end
+
+    test "returns false when both expired and used" do
+      code = %AuthorizationCode{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        used_at: DateTime.utc_now()
+      }
+
+      refute AuthorizationCode.valid_for_exchange?(code)
+    end
+  end
+
+  describe "mark_as_used/1" do
+    test "puts a used_at timestamp on the changeset" do
+      changeset = Ecto.Changeset.change(%AuthorizationCode{})
+      result = AuthorizationCode.mark_as_used(changeset)
+      assert %DateTime{} = Ecto.Changeset.get_change(result, :used_at)
+    end
+  end
+
+  describe "scopes_list/1" do
+    test "splits space-separated scopes into a list" do
+      code = %AuthorizationCode{scopes: "openid profile email"}
+      assert AuthorizationCode.scopes_list(code) == ["openid", "profile", "email"]
+    end
+
+    test "returns empty list when scopes is nil" do
+      assert AuthorizationCode.scopes_list(%AuthorizationCode{scopes: nil}) == []
+    end
+
+    test "ignores extra spaces" do
+      code = %AuthorizationCode{scopes: " openid  profile "}
+      result = AuthorizationCode.scopes_list(code)
+      assert "openid" in result
+      assert "profile" in result
+      refute "" in result
+    end
+  end
+
+  describe "verify_pkce/2" do
+    test "returns true when no PKCE was used (nil challenge)" do
+      code = %AuthorizationCode{code_challenge: nil, code_challenge_method: nil}
+      assert AuthorizationCode.verify_pkce(code, nil)
+      assert AuthorizationCode.verify_pkce(code, "any_verifier")
+    end
+
+    test "returns true for a valid S256 verifier" do
+      verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+      challenge = :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+
+      code = %AuthorizationCode{
+        code_challenge: challenge,
+        code_challenge_method: "S256"
+      }
+
+      assert AuthorizationCode.verify_pkce(code, verifier)
+    end
+
+    test "returns false for an invalid S256 verifier" do
+      challenge =
+        :crypto.hash(:sha256, "correct_verifier") |> Base.url_encode64(padding: false)
+
+      code = %AuthorizationCode{
+        code_challenge: challenge,
+        code_challenge_method: "S256"
+      }
+
+      refute AuthorizationCode.verify_pkce(code, "wrong_verifier")
+    end
+
+    test "returns true for a valid plain verifier" do
+      verifier = "my_plain_code_verifier"
+
+      code = %AuthorizationCode{
+        code_challenge: verifier,
+        code_challenge_method: "plain"
+      }
+
+      assert AuthorizationCode.verify_pkce(code, verifier)
+    end
+
+    test "returns false for an invalid plain verifier" do
+      code = %AuthorizationCode{
+        code_challenge: "correct_verifier",
+        code_challenge_method: "plain"
+      }
+
+      refute AuthorizationCode.verify_pkce(code, "wrong_verifier")
+    end
+
+    test "returns false when verifier is nil but challenge is set" do
+      code = %AuthorizationCode{
+        code_challenge: "some_challenge",
+        code_challenge_method: "S256"
+      }
+
+      refute AuthorizationCode.verify_pkce(code, nil)
+    end
+  end
+end

--- a/test/authify/o_auth/refresh_token_test.exs
+++ b/test/authify/o_auth/refresh_token_test.exs
@@ -1,0 +1,229 @@
+defmodule Authify.OAuth.RefreshTokenTest do
+  @moduledoc false
+  use Authify.DataCase, async: true
+
+  alias Authify.OAuth.RefreshToken
+
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
+  describe "changeset/2" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+      app = application_fixture(organization: org)
+      %{user: user, app: app}
+    end
+
+    test "valid changeset with required fields", %{user: user, app: app} do
+      attrs = %{scopes: "openid profile", application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "requires scopes", %{user: user, app: app} do
+      attrs = %{application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).scopes
+    end
+
+    test "requires application_id", %{user: user} do
+      attrs = %{scopes: "openid", user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).application_id
+    end
+
+    test "requires user_id", %{app: app} do
+      attrs = %{scopes: "openid", application_id: app.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      refute changeset.valid?
+      assert "can't be blank" in errors_on(changeset).user_id
+    end
+
+    test "auto-generates a hashed token when none provided", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      assert changeset.valid?
+      token_hash = Ecto.Changeset.get_change(changeset, :token)
+      assert is_binary(token_hash)
+      assert byte_size(token_hash) > 0
+    end
+
+    test "also stores plaintext_token as a virtual field", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      plaintext = Ecto.Changeset.get_change(changeset, :plaintext_token)
+      assert is_binary(plaintext)
+      assert byte_size(plaintext) > 0
+    end
+
+    test "stored token is the SHA-256 hash of the plaintext token", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      plaintext = Ecto.Changeset.get_change(changeset, :plaintext_token)
+      token_hash = Ecto.Changeset.get_change(changeset, :token)
+      assert RefreshToken.hash_token(plaintext) == token_hash
+    end
+
+    test "auto-generates expires_at approximately 30 days from now", %{user: user, app: app} do
+      attrs = %{scopes: "openid", application_id: app.id, user_id: user.id}
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      expires_at = Ecto.Changeset.get_change(changeset, :expires_at)
+      assert %DateTime{} = expires_at
+      diff = DateTime.diff(expires_at, DateTime.utc_now(), :second)
+      # Should be approximately 30 days (within 60 seconds tolerance)
+      assert diff > 30 * 24 * 60 * 60 - 60
+      assert diff <= 30 * 24 * 60 * 60
+    end
+
+    test "preserves an explicit expires_at when provided", %{user: user, app: app} do
+      custom_expires =
+        DateTime.utc_now() |> DateTime.add(7 * 24 * 3600, :second) |> DateTime.truncate(:second)
+
+      attrs = %{
+        scopes: "openid",
+        application_id: app.id,
+        user_id: user.id,
+        expires_at: custom_expires
+      }
+
+      changeset = RefreshToken.changeset(%RefreshToken{}, attrs)
+      assert Ecto.Changeset.get_change(changeset, :expires_at) == custom_expires
+    end
+  end
+
+  describe "expired?/1" do
+    test "returns false when expires_at is in the future" do
+      token = %RefreshToken{expires_at: DateTime.utc_now() |> DateTime.add(3600, :second)}
+      refute RefreshToken.expired?(token)
+    end
+
+    test "returns true when expires_at is in the past" do
+      token = %RefreshToken{expires_at: DateTime.utc_now() |> DateTime.add(-1, :second)}
+      assert RefreshToken.expired?(token)
+    end
+  end
+
+  describe "revoked?/1" do
+    test "returns false when revoked_at is nil" do
+      token = %RefreshToken{revoked_at: nil}
+      refute RefreshToken.revoked?(token)
+    end
+
+    test "returns true when revoked_at is set" do
+      token = %RefreshToken{revoked_at: DateTime.utc_now()}
+      assert RefreshToken.revoked?(token)
+    end
+  end
+
+  describe "valid?/1" do
+    test "returns true when not expired and not revoked" do
+      token = %RefreshToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(3600, :second),
+        revoked_at: nil
+      }
+
+      assert RefreshToken.valid?(token)
+    end
+
+    test "returns false when expired" do
+      token = %RefreshToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        revoked_at: nil
+      }
+
+      refute RefreshToken.valid?(token)
+    end
+
+    test "returns false when revoked" do
+      token = %RefreshToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(3600, :second),
+        revoked_at: DateTime.utc_now()
+      }
+
+      refute RefreshToken.valid?(token)
+    end
+
+    test "returns false when both expired and revoked" do
+      token = %RefreshToken{
+        expires_at: DateTime.utc_now() |> DateTime.add(-1, :second),
+        revoked_at: DateTime.utc_now()
+      }
+
+      refute RefreshToken.valid?(token)
+    end
+  end
+
+  describe "revoke/1" do
+    test "puts a revoked_at timestamp on the changeset" do
+      changeset = Ecto.Changeset.change(%RefreshToken{})
+      result = RefreshToken.revoke(changeset)
+      assert %DateTime{} = Ecto.Changeset.get_change(result, :revoked_at)
+    end
+  end
+
+  describe "scopes_list/1" do
+    test "splits space-separated scopes into a list" do
+      token = %RefreshToken{scopes: "openid profile email"}
+      assert RefreshToken.scopes_list(token) == ["openid", "profile", "email"]
+    end
+
+    test "returns a single-element list for a single scope" do
+      token = %RefreshToken{scopes: "openid"}
+      assert RefreshToken.scopes_list(token) == ["openid"]
+    end
+
+    test "returns empty list when scopes is nil" do
+      assert RefreshToken.scopes_list(%RefreshToken{scopes: nil}) == []
+    end
+
+    test "ignores leading/trailing spaces" do
+      token = %RefreshToken{scopes: " openid  profile "}
+      result = RefreshToken.scopes_list(token)
+      assert "openid" in result
+      assert "profile" in result
+      refute "" in result
+    end
+  end
+
+  describe "hash_token/1" do
+    test "returns a base64-encoded string" do
+      hash = RefreshToken.hash_token("some_plaintext_token")
+      assert is_binary(hash)
+      assert String.match?(hash, ~r/^[A-Za-z0-9+\/]+=*$/)
+    end
+
+    test "is deterministic for the same input" do
+      hash1 = RefreshToken.hash_token("my_token")
+      hash2 = RefreshToken.hash_token("my_token")
+      assert hash1 == hash2
+    end
+
+    test "produces different hashes for different inputs" do
+      hash1 = RefreshToken.hash_token("token_a")
+      hash2 = RefreshToken.hash_token("token_b")
+      refute hash1 == hash2
+    end
+  end
+
+  describe "verify_token/2" do
+    test "returns true when plaintext matches the stored hash" do
+      plaintext = "my_secret_refresh_token"
+      hash = RefreshToken.hash_token(plaintext)
+      assert RefreshToken.verify_token(plaintext, hash)
+    end
+
+    test "returns false when plaintext does not match the stored hash" do
+      hash = RefreshToken.hash_token("correct_token")
+      refute RefreshToken.verify_token("wrong_token", hash)
+    end
+
+    test "returns false when either argument is nil" do
+      refute RefreshToken.verify_token(nil, "some_hash")
+      refute RefreshToken.verify_token("some_token", nil)
+      refute RefreshToken.verify_token(nil, nil)
+    end
+  end
+end

--- a/test/authify/scopes_test.exs
+++ b/test/authify/scopes_test.exs
@@ -1,0 +1,247 @@
+defmodule Authify.ScopesTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+
+  alias Authify.Scopes
+
+  describe "oauth_scopes/0" do
+    test "includes the standard OIDC scopes" do
+      scopes = Scopes.oauth_scopes()
+      assert "openid" in scopes
+      assert "profile" in scopes
+      assert "email" in scopes
+      assert "phone" in scopes
+      assert "groups" in scopes
+    end
+
+    test "does not include management API scopes" do
+      scopes = Scopes.oauth_scopes()
+      refute "users:read" in scopes
+      refute "profile:read" in scopes
+    end
+  end
+
+  describe "management_api_scopes/0" do
+    test "includes user management scopes" do
+      scopes = Scopes.management_api_scopes()
+      assert "users:read" in scopes
+      assert "users:write" in scopes
+    end
+
+    test "includes application management scopes" do
+      scopes = Scopes.management_api_scopes()
+      assert "applications:read" in scopes
+      assert "applications:write" in scopes
+    end
+
+    test "includes audit log scope" do
+      assert "audit_logs:read" in Scopes.management_api_scopes()
+    end
+
+    test "does not include OAuth/OIDC scopes" do
+      scopes = Scopes.management_api_scopes()
+      refute "openid" in scopes
+      refute "profile" in scopes
+    end
+
+    test "does not include PAT-only scopes" do
+      scopes = Scopes.management_api_scopes()
+      refute "profile:read" in scopes
+      refute "profile:write" in scopes
+    end
+  end
+
+  describe "pat_only_scopes/0" do
+    test "returns profile:read and profile:write" do
+      scopes = Scopes.pat_only_scopes()
+      assert "profile:read" in scopes
+      assert "profile:write" in scopes
+    end
+
+    test "contains exactly the PAT-only scopes" do
+      assert length(Scopes.pat_only_scopes()) == 2
+    end
+  end
+
+  describe "scim_scopes/0" do
+    test "includes broad SCIM scopes" do
+      scopes = Scopes.scim_scopes()
+      assert "scim:read" in scopes
+      assert "scim:write" in scopes
+    end
+
+    test "includes resource-specific SCIM scopes" do
+      scopes = Scopes.scim_scopes()
+      assert "scim:users:read" in scopes
+      assert "scim:users:write" in scopes
+      assert "scim:groups:read" in scopes
+      assert "scim:groups:write" in scopes
+    end
+
+    test "includes self-service SCIM scopes" do
+      scopes = Scopes.scim_scopes()
+      assert "scim:me" in scopes
+      assert "scim:me:write" in scopes
+    end
+  end
+
+  describe "pat_scopes/0" do
+    test "includes all management API scopes" do
+      pat = Scopes.pat_scopes()
+
+      for scope <- Scopes.management_api_scopes() do
+        assert scope in pat
+      end
+    end
+
+    test "includes PAT-only scopes" do
+      pat = Scopes.pat_scopes()
+      assert "profile:read" in pat
+      assert "profile:write" in pat
+    end
+
+    test "includes SCIM scopes" do
+      pat = Scopes.pat_scopes()
+      assert "scim:read" in pat
+      assert "scim:write" in pat
+    end
+
+    test "does not include OAuth/OIDC scopes" do
+      pat = Scopes.pat_scopes()
+      refute "openid" in pat
+      refute "profile" in pat
+    end
+  end
+
+  describe "all_valid_scopes/0" do
+    test "includes OAuth scopes" do
+      all = Scopes.all_valid_scopes()
+      assert "openid" in all
+      assert "profile" in all
+    end
+
+    test "includes management API scopes" do
+      all = Scopes.all_valid_scopes()
+      assert "users:read" in all
+    end
+
+    test "includes PAT-only scopes" do
+      all = Scopes.all_valid_scopes()
+      assert "profile:read" in all
+    end
+
+    test "includes SCIM scopes" do
+      all = Scopes.all_valid_scopes()
+      assert "scim:read" in all
+    end
+  end
+
+  describe "valid_oauth_scope?/1" do
+    test "returns true for valid OAuth scopes" do
+      assert Scopes.valid_oauth_scope?("openid")
+      assert Scopes.valid_oauth_scope?("profile")
+      assert Scopes.valid_oauth_scope?("email")
+      assert Scopes.valid_oauth_scope?("phone")
+      assert Scopes.valid_oauth_scope?("groups")
+    end
+
+    test "returns false for management API scopes" do
+      refute Scopes.valid_oauth_scope?("users:read")
+      refute Scopes.valid_oauth_scope?("applications:write")
+    end
+
+    test "returns false for PAT-only scopes" do
+      refute Scopes.valid_oauth_scope?("profile:read")
+      refute Scopes.valid_oauth_scope?("profile:write")
+    end
+
+    test "returns false for unknown scopes" do
+      refute Scopes.valid_oauth_scope?("nonexistent")
+      refute Scopes.valid_oauth_scope?("")
+    end
+  end
+
+  describe "valid_management_api_scope?/1" do
+    test "returns true for valid management API scopes" do
+      assert Scopes.valid_management_api_scope?("users:read")
+      assert Scopes.valid_management_api_scope?("applications:write")
+      assert Scopes.valid_management_api_scope?("audit_logs:read")
+    end
+
+    test "returns false for OAuth scopes" do
+      refute Scopes.valid_management_api_scope?("openid")
+      refute Scopes.valid_management_api_scope?("profile")
+    end
+
+    test "returns false for PAT-only scopes" do
+      refute Scopes.valid_management_api_scope?("profile:read")
+    end
+
+    test "returns false for unknown scopes" do
+      refute Scopes.valid_management_api_scope?("nonexistent")
+    end
+  end
+
+  describe "valid_scope?/1" do
+    test "returns true for OAuth scopes" do
+      assert Scopes.valid_scope?("openid")
+      assert Scopes.valid_scope?("profile")
+    end
+
+    test "returns true for management API scopes" do
+      assert Scopes.valid_scope?("users:read")
+      assert Scopes.valid_scope?("applications:write")
+    end
+
+    test "returns true for PAT-only scopes" do
+      assert Scopes.valid_scope?("profile:read")
+      assert Scopes.valid_scope?("profile:write")
+    end
+
+    test "returns true for SCIM scopes" do
+      assert Scopes.valid_scope?("scim:read")
+      assert Scopes.valid_scope?("scim:me")
+    end
+
+    test "returns false for unknown scopes" do
+      refute Scopes.valid_scope?("nonexistent")
+      refute Scopes.valid_scope?("")
+      refute Scopes.valid_scope?("admin")
+    end
+  end
+
+  describe "scopes_by_category/0" do
+    test "returns a map" do
+      assert is_map(Scopes.scopes_by_category())
+    end
+
+    test "contains expected top-level categories" do
+      categories = Map.keys(Scopes.scopes_by_category())
+      assert "OAuth/OIDC" in categories
+      assert "User Management" in categories
+      assert "SCIM 2.0 Provisioning" in categories
+      assert "Profile" in categories
+    end
+
+    test "each category value is a list of {scope, description} tuples" do
+      Scopes.scopes_by_category()
+      |> Enum.each(fn {_category, entries} ->
+        assert is_list(entries)
+
+        Enum.each(entries, fn entry ->
+          assert {scope, description} = entry
+          assert is_binary(scope)
+          assert is_binary(description)
+        end)
+      end)
+    end
+
+    test "all scopes in the map are valid scopes" do
+      Scopes.scopes_by_category()
+      |> Enum.flat_map(fn {_cat, entries} -> Enum.map(entries, &elem(&1, 0)) end)
+      |> Enum.each(fn scope ->
+        assert Scopes.valid_scope?(scope), "#{scope} in scopes_by_category is not a valid scope"
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `Accounts.Group` and `Accounts.GroupMembership` — changeset validations, all CRUD/filtering/membership context functions (45 tests)
- Add dedicated unit test files for six previously untested security-critical modules: `OAuth.RefreshToken`, `OAuth.AuthorizationCode`, `OAuth.AccessToken`, `Authify.Encryption`, `Authify.Scopes`, and `Accounts.UserEmail` (149 tests)

## Key security areas now covered

- **Token hashing/verification** (`RefreshToken.hash_token/1`, `verify_token/2`) — prevents stolen hash from being replayed as plaintext
- **PKCE validation** (`AuthorizationCode.verify_pkce/2`) — S256 and plain methods, including nil/invalid cases
- **Token state** (`expired?`, `revoked?`, `valid?`) across all three OAuth token types
- **AES-256-GCM encryption** — roundtrip correctness, random IV/salt per call, wrong-password and corrupted-data error paths
- **Scope validation** — `valid_oauth_scope?`, `valid_management_api_scope?`, `valid_scope?`, and `scopes_by_category` integrity
- **Email verification** — `verify_changeset/1` and `verification_token_changeset/2` (SHA-256 hashing, not plaintext storage)

## Test Plan
- [x] `mix test` passes (1784 tests, 0 failures)
- [x] `mix credo` passes with no issues
- [x] All new test files use `async: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)