### PR TITLE
feat(oidc): add nonce parameter support per OIDC Core §2 and §12.2

### DIFF
--- a/lib/authify/o_auth.ex
+++ b/lib/authify/o_auth.ex
@@ -416,10 +416,11 @@ defmodule Authify.OAuth do
                 application,
                 user,
                 auth_code.scopes,
-                access_token.id
+                access_token.id,
+                auth_code.nonce
               )
 
-            rt
+            Repo.preload(rt, [:application, :user])
           else
             nil
           end
@@ -649,13 +650,15 @@ defmodule Authify.OAuth do
         %Application{} = application,
         %User{} = user,
         scopes,
-        access_token_id \\ nil
+        access_token_id \\ nil,
+        nonce \\ nil
       ) do
     attrs = %{
       application_id: application.id,
       user_id: user.id,
       scopes: scopes,
-      access_token_id: access_token_id
+      access_token_id: access_token_id,
+      nonce: nonce
     }
 
     %RefreshToken{}
@@ -711,7 +714,8 @@ defmodule Authify.OAuth do
                 refresh_token.application,
                 refresh_token.user,
                 refresh_token.scopes,
-                access_token.id
+                access_token.id,
+                refresh_token.nonce
               )
 
             new_rt

--- a/lib/authify/o_auth.ex
+++ b/lib/authify/o_auth.ex
@@ -718,7 +718,7 @@ defmodule Authify.OAuth do
                 refresh_token.nonce
               )
 
-            new_rt
+            Repo.preload(new_rt, [:application, :user])
           else
             refresh_token
           end

--- a/lib/authify/o_auth/authorization_code.ex
+++ b/lib/authify/o_auth/authorization_code.ex
@@ -41,6 +41,7 @@ defmodule Authify.OAuth.AuthorizationCode do
       :user_id
     ])
     |> validate_required([:redirect_uri, :scopes, :application_id, :user_id])
+    |> validate_length(:nonce, max: 2048)
     |> validate_pkce()
     |> put_code()
     |> put_expires_at()

--- a/lib/authify/o_auth/authorization_code.ex
+++ b/lib/authify/o_auth/authorization_code.ex
@@ -16,6 +16,8 @@ defmodule Authify.OAuth.AuthorizationCode do
     # PKCE fields
     field :code_challenge, :string
     field :code_challenge_method, :string
+    # OIDC nonce
+    field :nonce, :string
 
     belongs_to :application, Authify.OAuth.Application
     belongs_to :user, Authify.Accounts.User
@@ -34,6 +36,7 @@ defmodule Authify.OAuth.AuthorizationCode do
       :used_at,
       :code_challenge,
       :code_challenge_method,
+      :nonce,
       :application_id,
       :user_id
     ])

--- a/lib/authify/o_auth/refresh_token.ex
+++ b/lib/authify/o_auth/refresh_token.ex
@@ -12,6 +12,8 @@ defmodule Authify.OAuth.RefreshToken do
     field :scopes, :string
     field :expires_at, :utc_datetime
     field :revoked_at, :utc_datetime
+    # OIDC nonce — propagated from the original authorization code
+    field :nonce, :string
 
     belongs_to :application, Authify.OAuth.Application
     belongs_to :user, Authify.Accounts.User
@@ -28,6 +30,7 @@ defmodule Authify.OAuth.RefreshToken do
       :scopes,
       :expires_at,
       :revoked_at,
+      :nonce,
       :application_id,
       :user_id,
       :access_token_id

--- a/lib/authify/o_auth/refresh_token.ex
+++ b/lib/authify/o_auth/refresh_token.ex
@@ -36,6 +36,7 @@ defmodule Authify.OAuth.RefreshToken do
       :access_token_id
     ])
     |> validate_required([:scopes, :application_id, :user_id])
+    |> validate_length(:nonce, max: 2048)
     |> put_token()
     |> put_expires_at()
     |> unique_constraint(:token)

--- a/lib/authify_web/controllers/oauth_controller.ex
+++ b/lib/authify_web/controllers/oauth_controller.ex
@@ -456,6 +456,7 @@ defmodule AuthifyWeb.OAuthController do
          {:ok, auth_code} <- get_authorization_code(params["code"]),
          :ok <- verify_pkce(auth_code, params["code_verifier"]),
          {:ok, result} <- OAuth.exchange_authorization_code(auth_code, application) do
+      nonce = auth_code.nonce
       access_token = result.access_token
       refresh_token = result.refresh_token
 
@@ -470,7 +471,7 @@ defmodule AuthifyWeb.OAuthController do
       )
 
       response =
-        build_token_response_with_refresh_and_id(access_token, refresh_token, organization)
+        build_token_response_with_refresh_and_id(access_token, refresh_token, organization, nonce)
 
       json(conn, response)
     else
@@ -487,10 +488,10 @@ defmodule AuthifyWeb.OAuthController do
     end
   end
 
-  defp build_token_response_with_refresh_and_id(access_token, refresh_token, organization) do
+  defp build_token_response_with_refresh_and_id(access_token, refresh_token, organization, nonce) do
     build_token_response(access_token)
     |> maybe_add_refresh_token(refresh_token)
-    |> maybe_add_id_token(access_token, organization)
+    |> maybe_add_id_token(access_token, organization, nonce)
   end
 
   defp maybe_add_refresh_token(response, nil), do: response
@@ -499,9 +500,9 @@ defmodule AuthifyWeb.OAuthController do
     Map.put(response, :refresh_token, refresh_token.token)
   end
 
-  defp maybe_add_id_token(response, access_token, organization) do
+  defp maybe_add_id_token(response, access_token, organization, nonce \\ nil) do
     if "openid" in OAuth.AccessToken.scopes_list(access_token) do
-      case generate_id_token(access_token, organization) do
+      case generate_id_token(access_token, organization, nonce) do
         {:ok, id_token} ->
           Map.put(response, :id_token, id_token)
 
@@ -704,10 +705,10 @@ defmodule AuthifyWeb.OAuthController do
     end
   end
 
-  defp generate_id_token(access_token, organization) do
+  defp generate_id_token(access_token, organization, nonce) do
     with {:ok, certificate} <- Accounts.get_or_generate_oauth_signing_certificate(organization),
          {:ok, private_key} <- load_private_key(certificate) do
-      sign_id_token(access_token, organization, certificate, private_key)
+      sign_id_token(access_token, organization, certificate, private_key, nonce)
     end
   end
 
@@ -722,7 +723,7 @@ defmodule AuthifyWeb.OAuthController do
     error -> {:error, {:pem_decode_failed, error}}
   end
 
-  defp sign_id_token(access_token, organization, certificate, private_key) do
+  defp sign_id_token(access_token, organization, certificate, private_key, nonce) do
     user = access_token.user
     scopes = OAuth.AccessToken.scopes_list(access_token)
     org_base_url = "#{AuthifyWeb.Endpoint.url()}/#{organization.slug}"
@@ -740,6 +741,7 @@ defmodule AuthifyWeb.OAuthController do
       }
       |> maybe_add_profile_claims(user, scopes)
       |> maybe_add_email_claims(user, scopes)
+      |> maybe_add_nonce_claim(nonce)
 
     encoded_header = Base.url_encode64(Jason.encode!(header), padding: false)
     encoded_claims = Base.url_encode64(Jason.encode!(claims), padding: false)
@@ -752,6 +754,9 @@ defmodule AuthifyWeb.OAuthController do
   rescue
     error -> {:error, {:signing_failed, error}}
   end
+
+  defp maybe_add_nonce_claim(claims, nil), do: claims
+  defp maybe_add_nonce_claim(claims, nonce), do: Map.put(claims, "nonce", nonce)
 
   defp maybe_add_profile_claims(claims, user, scopes) do
     if "profile" in scopes do

--- a/lib/authify_web/controllers/oauth_controller.ex
+++ b/lib/authify_web/controllers/oauth_controller.ex
@@ -497,7 +497,7 @@ defmodule AuthifyWeb.OAuthController do
   defp maybe_add_refresh_token(response, nil), do: response
 
   defp maybe_add_refresh_token(response, refresh_token) do
-    Map.put(response, :refresh_token, refresh_token.token)
+    Map.put(response, :refresh_token, refresh_token.plaintext_token)
   end
 
   defp maybe_add_id_token(response, access_token, organization, nonce) do
@@ -581,7 +581,7 @@ defmodule AuthifyWeb.OAuthController do
       token_type: "Bearer",
       expires_in: 3600,
       scope: access_token.scopes,
-      refresh_token: new_refresh_token.token
+      refresh_token: new_refresh_token.plaintext_token
     }
     |> maybe_add_id_token(access_token, organization, nonce)
   end

--- a/lib/authify_web/controllers/oauth_controller.ex
+++ b/lib/authify_web/controllers/oauth_controller.ex
@@ -500,7 +500,7 @@ defmodule AuthifyWeb.OAuthController do
     Map.put(response, :refresh_token, refresh_token.token)
   end
 
-  defp maybe_add_id_token(response, access_token, organization, nonce \\ nil) do
+  defp maybe_add_id_token(response, access_token, organization, nonce) do
     if "openid" in OAuth.AccessToken.scopes_list(access_token) do
       case generate_id_token(access_token, organization, nonce) do
         {:ok, id_token} ->
@@ -552,6 +552,7 @@ defmodule AuthifyWeb.OAuthController do
          {:ok, refresh_token} <- get_refresh_token(params["refresh_token"]),
          :ok <- verify_refresh_token_application(refresh_token, application),
          {:ok, result} <- OAuth.exchange_refresh_token(refresh_token) do
+      nonce = result.refresh_token.nonce
       access_token = result.access_token
       new_refresh_token = result.refresh_token
 
@@ -563,7 +564,9 @@ defmodule AuthifyWeb.OAuthController do
         "refresh_token"
       )
 
-      response = build_refresh_token_response(access_token, new_refresh_token, organization)
+      response =
+        build_refresh_token_response(access_token, new_refresh_token, organization, nonce)
+
       json(conn, response)
     else
       {:error, error} ->
@@ -572,7 +575,7 @@ defmodule AuthifyWeb.OAuthController do
     end
   end
 
-  defp build_refresh_token_response(access_token, new_refresh_token, organization) do
+  defp build_refresh_token_response(access_token, new_refresh_token, organization, nonce) do
     %{
       access_token: access_token.token,
       token_type: "Bearer",
@@ -580,7 +583,7 @@ defmodule AuthifyWeb.OAuthController do
       scope: access_token.scopes,
       refresh_token: new_refresh_token.token
     }
-    |> maybe_add_id_token(access_token, organization)
+    |> maybe_add_id_token(access_token, organization, nonce)
   end
 
   defp handle_refresh_token_error(conn, :invalid_client) do

--- a/lib/authify_web/controllers/oauth_controller.ex
+++ b/lib/authify_web/controllers/oauth_controller.ex
@@ -96,8 +96,15 @@ defmodule AuthifyWeb.OAuthController do
          {:ok, redirect_uri} <- validate_redirect_uri(application, params["redirect_uri"]),
          {:ok, scopes} <- validate_scopes(application, params["scope"]),
          pkce_params = extract_pkce_params(params),
+         nonce_params = extract_nonce_param(params),
          {:ok, auth_code} <-
-           OAuth.create_authorization_code(application, user, redirect_uri, scopes, pkce_params) do
+           OAuth.create_authorization_code(
+             application,
+             user,
+             redirect_uri,
+             scopes,
+             Map.merge(pkce_params, nonce_params)
+           ) do
       {:ok,
        %{
          application: application,
@@ -315,6 +322,7 @@ defmodule AuthifyWeb.OAuthController do
       state: params["state"],
       code_challenge: params["code_challenge"],
       code_challenge_method: params["code_challenge_method"],
+      nonce: params["nonce"],
       organization: organization,
       layout: false
     })
@@ -377,10 +385,16 @@ defmodule AuthifyWeb.OAuthController do
          params
        ) do
     pkce_params = extract_pkce_params(params)
+    nonce_params = extract_nonce_param(params)
 
-    case OAuth.create_authorization_code(application, user, redirect_uri, scopes, pkce_params) do
+    case OAuth.create_authorization_code(
+           application,
+           user,
+           redirect_uri,
+           scopes,
+           Map.merge(pkce_params, nonce_params)
+         ) do
       {:ok, auth_code} ->
-        # Log auto-approved authorization
         AuditLogger.log_authorization_auto_approved(
           conn,
           organization,
@@ -398,7 +412,6 @@ defmodule AuthifyWeb.OAuthController do
         {:auto_approve, redirect_url}
 
       {:error, _} ->
-        # Failed to create auth code, show consent screen
         :show_consent
     end
   end
@@ -407,6 +420,11 @@ defmodule AuthifyWeb.OAuthController do
     %{}
     |> maybe_add_param(:code_challenge, params["code_challenge"])
     |> maybe_add_param(:code_challenge_method, params["code_challenge_method"])
+  end
+
+  defp extract_nonce_param(params) do
+    %{}
+    |> maybe_add_param(:nonce, params["nonce"])
   end
 
   defp maybe_add_param(map, _key, nil), do: map

--- a/lib/authify_web/controllers/oauth_html/consent.html.heex
+++ b/lib/authify_web/controllers/oauth_html/consent.html.heex
@@ -87,6 +87,9 @@
                         value={@code_challenge_method}
                       />
                     <% end %>
+                    <%= if @nonce do %>
+                      <input type="hidden" name="nonce" value={@nonce} />
+                    <% end %>
                     <input type="hidden" name="approve" value="false" />
                     <button type="submit" class="btn btn-outline-secondary w-100">
                       <i class="bi bi-x-circle"></i> Deny
@@ -115,6 +118,9 @@
                         name="code_challenge_method"
                         value={@code_challenge_method}
                       />
+                    <% end %>
+                    <%= if @nonce do %>
+                      <input type="hidden" name="nonce" value={@nonce} />
                     <% end %>
                     <input type="hidden" name="approve" value="true" />
                     <button type="submit" class="btn btn-primary w-100">

--- a/lib/authify_web/controllers/oidc_controller.ex
+++ b/lib/authify_web/controllers/oidc_controller.ex
@@ -38,7 +38,8 @@ defmodule AuthifyWeb.OIDCController do
         "email_verified",
         "phone_number",
         "phone_number_verified",
-        "updated_at"
+        "updated_at",
+        "nonce"
       ],
       grant_types_supported: ["authorization_code"],
       response_modes_supported: ["query"],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.16.3",
+      version: "0.16.4",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260415035410_add_nonce_to_authorization_codes.exs
+++ b/priv/repo/migrations/20260415035410_add_nonce_to_authorization_codes.exs
@@ -1,0 +1,9 @@
+defmodule Authify.Repo.Migrations.AddNonceToAuthorizationCodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:authorization_codes) do
+      add :nonce, :string, size: 2048
+    end
+  end
+end

--- a/priv/repo/migrations/20260415035411_add_nonce_to_refresh_tokens.exs
+++ b/priv/repo/migrations/20260415035411_add_nonce_to_refresh_tokens.exs
@@ -1,0 +1,9 @@
+defmodule Authify.Repo.Migrations.AddNonceToRefreshTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:refresh_tokens) do
+      add :nonce, :string, size: 2048
+    end
+  end
+end

--- a/test/authify/o_auth_test.exs
+++ b/test/authify/o_auth_test.exs
@@ -481,5 +481,24 @@ defmodule Authify.OAuthTest do
 
       assert is_nil(auth_code.nonce)
     end
+
+    test "create_authorization_code rejects nonce exceeding 2048 characters", %{
+      application: application,
+      user: user
+    } do
+      oversized_nonce = String.duplicate("x", 2049)
+
+      assert {:error, changeset} =
+               OAuth.create_authorization_code(
+                 application,
+                 user,
+                 "https://example.com/callback",
+                 ["openid", "profile"],
+                 %{nonce: oversized_nonce}
+               )
+
+      assert {"should be at most %{count} character(s)", _} =
+               Keyword.fetch!(changeset.errors, :nonce)
+    end
   end
 end

--- a/test/authify/o_auth_test.exs
+++ b/test/authify/o_auth_test.exs
@@ -362,4 +362,44 @@ defmodule Authify.OAuthTest do
       assert String.starts_with?(claims["picture"], "https://www.gravatar.com/avatar/")
     end
   end
+
+  describe "authorization_codes nonce" do
+    setup do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+      application = application_fixture(organization: organization)
+      %{organization: organization, user: user, application: application}
+    end
+
+    test "create_authorization_code stores nonce when provided", %{
+      application: application,
+      user: user
+    } do
+      {:ok, auth_code} =
+        OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"],
+          %{nonce: "my_test_nonce"}
+        )
+
+      assert auth_code.nonce == "my_test_nonce"
+    end
+
+    test "create_authorization_code stores nil nonce when not provided", %{
+      application: application,
+      user: user
+    } do
+      {:ok, auth_code} =
+        OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"]
+        )
+
+      assert is_nil(auth_code.nonce)
+    end
+  end
 end

--- a/test/authify/o_auth_test.exs
+++ b/test/authify/o_auth_test.exs
@@ -363,6 +363,86 @@ defmodule Authify.OAuthTest do
     end
   end
 
+  describe "refresh_tokens nonce" do
+    setup do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+      application = application_fixture(organization: organization)
+      %{organization: organization, user: user, application: application}
+    end
+
+    test "create_refresh_token stores nonce when provided", %{
+      application: application,
+      user: user
+    } do
+      {:ok, rt} =
+        OAuth.create_refresh_token(application, user, "openid profile", nil, "nonce_abc")
+
+      assert rt.nonce == "nonce_abc"
+    end
+
+    test "create_refresh_token stores nil nonce when not provided", %{
+      application: application,
+      user: user
+    } do
+      {:ok, rt} = OAuth.create_refresh_token(application, user, "openid profile")
+      assert is_nil(rt.nonce)
+    end
+
+    test "exchange_authorization_code propagates nonce to refresh token", %{
+      application: application,
+      user: user
+    } do
+      {:ok, auth_code} =
+        OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"],
+          %{nonce: "propagate_me"}
+        )
+
+      {:ok, result} = OAuth.exchange_authorization_code(auth_code, application)
+      assert result.refresh_token.nonce == "propagate_me"
+    end
+
+    test "exchange_authorization_code propagates nil nonce when not set", %{
+      application: application,
+      user: user
+    } do
+      {:ok, auth_code} =
+        OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"]
+        )
+
+      {:ok, result} = OAuth.exchange_authorization_code(auth_code, application)
+      assert is_nil(result.refresh_token.nonce)
+    end
+
+    test "exchange_refresh_token preserves nonce in rotated refresh token", %{
+      application: application,
+      user: user
+    } do
+      {:ok, auth_code} =
+        OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"],
+          %{nonce: "rotation_nonce"}
+        )
+
+      {:ok, result} = OAuth.exchange_authorization_code(auth_code, application)
+      original_rt = result.refresh_token
+
+      {:ok, rotated} = OAuth.exchange_refresh_token(original_rt)
+      assert rotated.refresh_token.nonce == "rotation_nonce"
+    end
+  end
+
   describe "authorization_codes nonce" do
     setup do
       organization = organization_fixture()

--- a/test/authify_web/controllers/oauth_controller_test.exs
+++ b/test/authify_web/controllers/oauth_controller_test.exs
@@ -73,6 +73,28 @@ defmodule AuthifyWeb.OAuthControllerTest do
       assert redirected_to(conn) =~ "https://example.com/callback"
       assert redirected_to(conn) =~ "error=invalid_client"
     end
+
+    test "renders nonce as hidden field in consent screen when provided", %{
+      conn: conn,
+      user: user,
+      application: application,
+      organization: organization
+    } do
+      conn = log_in_user(conn, user)
+
+      params = %{
+        "client_id" => application.client_id,
+        "redirect_uri" => "https://example.com/callback",
+        "response_type" => "code",
+        "scope" => "openid profile",
+        "nonce" => "test_nonce_xyz"
+      }
+
+      conn = get(conn, ~p"/#{organization.slug}/oauth/authorize", params)
+      body = html_response(conn, 200)
+      assert body =~ ~s(name="nonce")
+      assert body =~ ~s(value="test_nonce_xyz")
+    end
   end
 
   describe "consent" do
@@ -126,6 +148,57 @@ defmodule AuthifyWeb.OAuthControllerTest do
       conn = post(conn, ~p"/#{organization.slug}/oauth/consent", params)
       assert redirected_to(conn) =~ "https://example.com/callback"
       assert redirected_to(conn) =~ "error=access_denied"
+    end
+
+    test "stores nonce on authorization code when provided in consent params", %{
+      conn: conn,
+      user: user,
+      application: application,
+      organization: organization
+    } do
+      conn = log_in_user(conn, user)
+
+      params = %{
+        "client_id" => application.client_id,
+        "redirect_uri" => "https://example.com/callback",
+        "scope" => "openid profile",
+        "approve" => "true",
+        "nonce" => "consent_nonce_456"
+      }
+
+      conn = post(conn, ~p"/#{organization.slug}/oauth/consent", params)
+      redirect_url = redirected_to(conn)
+
+      uri = URI.parse(redirect_url)
+      query = URI.decode_query(uri.query)
+      auth_code = Authify.OAuth.get_authorization_code(query["code"])
+
+      assert auth_code.nonce == "consent_nonce_456"
+    end
+
+    test "authorization code has nil nonce when not provided in consent params", %{
+      conn: conn,
+      user: user,
+      application: application,
+      organization: organization
+    } do
+      conn = log_in_user(conn, user)
+
+      params = %{
+        "client_id" => application.client_id,
+        "redirect_uri" => "https://example.com/callback",
+        "scope" => "openid profile",
+        "approve" => "true"
+      }
+
+      conn = post(conn, ~p"/#{organization.slug}/oauth/consent", params)
+      redirect_url = redirected_to(conn)
+
+      uri = URI.parse(redirect_url)
+      query = URI.decode_query(uri.query)
+      auth_code = Authify.OAuth.get_authorization_code(query["code"])
+
+      assert is_nil(auth_code.nonce)
     end
   end
 

--- a/test/authify_web/controllers/oauth_controller_test.exs
+++ b/test/authify_web/controllers/oauth_controller_test.exs
@@ -280,6 +280,61 @@ defmodule AuthifyWeb.OAuthControllerTest do
       response = json_response(conn, 401)
       assert response["error"] == "invalid_client"
     end
+
+    test "ID token includes nonce claim when authorization code had a nonce", %{
+      conn: conn,
+      application: application,
+      user: user,
+      organization: organization
+    } do
+      {:ok, auth_code_with_nonce} =
+        Authify.OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"],
+          %{nonce: "id_token_nonce_test"}
+        )
+
+      params = %{
+        "grant_type" => "authorization_code",
+        "client_id" => application.client_id,
+        "client_secret" => application.client_secret,
+        "code" => auth_code_with_nonce.code
+      }
+
+      conn = post(conn, ~p"/#{organization.slug}/oauth/token", params)
+      response = json_response(conn, 200)
+
+      id_token = response["id_token"]
+      [_header, payload, _sig] = String.split(id_token, ".")
+      claims = payload |> Base.url_decode64!(padding: false) |> Jason.decode!()
+
+      assert claims["nonce"] == "id_token_nonce_test"
+    end
+
+    test "ID token omits nonce claim when authorization code had no nonce", %{
+      conn: conn,
+      application: application,
+      auth_code: auth_code,
+      organization: organization
+    } do
+      params = %{
+        "grant_type" => "authorization_code",
+        "client_id" => application.client_id,
+        "client_secret" => application.client_secret,
+        "code" => auth_code.code
+      }
+
+      conn = post(conn, ~p"/#{organization.slug}/oauth/token", params)
+      response = json_response(conn, 200)
+
+      id_token = response["id_token"]
+      [_header, payload, _sig] = String.split(id_token, ".")
+      claims = payload |> Base.url_decode64!(padding: false) |> Jason.decode!()
+
+      refute Map.has_key?(claims, "nonce")
+    end
   end
 
   describe "client credentials token" do

--- a/test/authify_web/controllers/oauth_real_world_flows_test.exs
+++ b/test/authify_web/controllers/oauth_real_world_flows_test.exs
@@ -421,6 +421,142 @@ defmodule AuthifyWeb.OAuthRealWorldFlowsTest do
     end
   end
 
+  describe "OIDC nonce propagation" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+
+      {:ok, app} =
+        Authify.OAuth.create_application(%{
+          "name" => "Nonce Test App",
+          "scopes" => "openid profile",
+          "redirect_uris" => "https://example.com/callback",
+          "organization_id" => org.id,
+          "application_type" => "oauth2_app"
+        })
+
+      %{org: org, user: user, app: app}
+    end
+
+    test "auto-approve path stores nonce on auth code and includes it in ID token", %{
+      org: org,
+      user: user,
+      app: app
+    } do
+      # Pre-create a user grant so the authorize endpoint auto-approves (skips consent screen)
+      {:ok, _grant} = Authify.OAuth.create_or_update_user_grant(user, app, ["openid", "profile"])
+
+      conn = build_conn() |> log_in_user(user)
+
+      conn =
+        get(conn, ~p"/#{org.slug}/oauth/authorize", %{
+          "client_id" => app.client_id,
+          "redirect_uri" => "https://example.com/callback",
+          "response_type" => "code",
+          "scope" => "openid profile",
+          "nonce" => "auto_approve_nonce"
+        })
+
+      # Should redirect directly to callback, not show consent screen
+      redirect_url = redirected_to(conn)
+      assert redirect_url =~ "https://example.com/callback"
+      assert redirect_url =~ "code="
+
+      uri = URI.parse(redirect_url)
+      query = URI.decode_query(uri.query)
+      code = query["code"]
+
+      conn = build_conn()
+
+      conn =
+        post(conn, ~p"/#{org.slug}/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "client_id" => app.client_id,
+          "client_secret" => app.client_secret,
+          "code" => code
+        })
+
+      response = json_response(conn, 200)
+      assert response["id_token"]
+
+      [_header, payload, _sig] = String.split(response["id_token"], ".")
+      claims = payload |> Base.url_decode64!(padding: false) |> Jason.decode!()
+
+      assert claims["nonce"] == "auto_approve_nonce"
+    end
+
+    test "refresh token grant includes nonce in ID token (OIDC §12.2)", %{
+      org: org,
+      user: user,
+      app: app
+    } do
+      {:ok, auth_code} =
+        Authify.OAuth.create_authorization_code(
+          app,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"],
+          %{nonce: "s12_2_compliance_nonce"}
+        )
+
+      {:ok, result} = Authify.OAuth.exchange_authorization_code(auth_code, app)
+      plaintext_refresh_token = result.refresh_token.plaintext_token
+
+      conn = build_conn()
+
+      conn =
+        post(conn, ~p"/#{org.slug}/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "client_id" => app.client_id,
+          "client_secret" => app.client_secret,
+          "refresh_token" => plaintext_refresh_token
+        })
+
+      response = json_response(conn, 200)
+      assert response["id_token"]
+
+      [_header, payload, _sig] = String.split(response["id_token"], ".")
+      claims = payload |> Base.url_decode64!(padding: false) |> Jason.decode!()
+
+      assert claims["nonce"] == "s12_2_compliance_nonce"
+    end
+
+    test "refresh token grant omits nonce in ID token when original request had none", %{
+      org: org,
+      user: user,
+      app: app
+    } do
+      {:ok, auth_code} =
+        Authify.OAuth.create_authorization_code(
+          app,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"]
+        )
+
+      {:ok, result} = Authify.OAuth.exchange_authorization_code(auth_code, app)
+      plaintext_refresh_token = result.refresh_token.plaintext_token
+
+      conn = build_conn()
+
+      conn =
+        post(conn, ~p"/#{org.slug}/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "client_id" => app.client_id,
+          "client_secret" => app.client_secret,
+          "refresh_token" => plaintext_refresh_token
+        })
+
+      response = json_response(conn, 200)
+      assert response["id_token"]
+
+      [_header, payload, _sig] = String.split(response["id_token"], ".")
+      claims = payload |> Base.url_decode64!(padding: false) |> Jason.decode!()
+
+      refute Map.has_key?(claims, "nonce")
+    end
+  end
+
   describe "Management API access flow" do
     test "complete flow: create mgmt app, get token, access API" do
       # Step 1: Create organization and admin

--- a/test/authify_web/controllers/oauth_real_world_flows_test.exs
+++ b/test/authify_web/controllers/oauth_real_world_flows_test.exs
@@ -499,17 +499,24 @@ defmodule AuthifyWeb.OAuthRealWorldFlowsTest do
           %{nonce: "s12_2_compliance_nonce"}
         )
 
-      {:ok, result} = Authify.OAuth.exchange_authorization_code(auth_code, app)
-      plaintext_refresh_token = result.refresh_token.plaintext_token
+      # Exchange via HTTP so we exercise the token endpoint response (plaintext refresh token)
+      token_conn =
+        post(build_conn(), ~p"/#{org.slug}/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "client_id" => app.client_id,
+          "client_secret" => app.client_secret,
+          "code" => auth_code.code
+        })
 
-      conn = build_conn()
+      token_response = json_response(token_conn, 200)
+      refresh_token = token_response["refresh_token"]
 
       conn =
-        post(conn, ~p"/#{org.slug}/oauth/token", %{
+        post(build_conn(), ~p"/#{org.slug}/oauth/token", %{
           "grant_type" => "refresh_token",
           "client_id" => app.client_id,
           "client_secret" => app.client_secret,
-          "refresh_token" => plaintext_refresh_token
+          "refresh_token" => refresh_token
         })
 
       response = json_response(conn, 200)
@@ -534,17 +541,24 @@ defmodule AuthifyWeb.OAuthRealWorldFlowsTest do
           ["openid", "profile"]
         )
 
-      {:ok, result} = Authify.OAuth.exchange_authorization_code(auth_code, app)
-      plaintext_refresh_token = result.refresh_token.plaintext_token
+      # Exchange via HTTP so we exercise the token endpoint response (plaintext refresh token)
+      token_conn =
+        post(build_conn(), ~p"/#{org.slug}/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "client_id" => app.client_id,
+          "client_secret" => app.client_secret,
+          "code" => auth_code.code
+        })
 
-      conn = build_conn()
+      token_response = json_response(token_conn, 200)
+      refresh_token = token_response["refresh_token"]
 
       conn =
-        post(conn, ~p"/#{org.slug}/oauth/token", %{
+        post(build_conn(), ~p"/#{org.slug}/oauth/token", %{
           "grant_type" => "refresh_token",
           "client_id" => app.client_id,
           "client_secret" => app.client_secret,
-          "refresh_token" => plaintext_refresh_token
+          "refresh_token" => refresh_token
         })
 
       response = json_response(conn, 200)


### PR DESCRIPTION
## Summary

- Accepts `nonce` parameter in authorization requests and stores it on `authorization_codes` and `refresh_tokens`
- Echoes the nonce verbatim in ID tokens issued via the authorization code grant (OIDC Core §2)
- Propagates nonce unchanged through refresh token rotation so refresh-issued ID tokens carry the original nonce (OIDC Core §12.2)
- Adds `"nonce"` to `claims_supported` in the OIDC discovery document

## Changes

- **Migrations**: `nonce` column (string, 2048) added to `authorization_codes` and `refresh_tokens`
- **Schemas**: `AuthorizationCode` and `RefreshToken` schemas updated with optional nonce field
- **OAuth context**: `create_refresh_token/5` accepts nonce; `exchange_authorization_code` and `exchange_refresh_token` propagate it
- **OAuthController**: extracts nonce from auth params, threads through consent form, includes in ID token via `maybe_add_nonce_claim/2`
- **OIDCController**: `"nonce"` added to `claims_supported`
- **Consent template**: hidden nonce field in both approve and deny forms

## Test Plan

- [x] Unit tests: nonce stored on auth codes and refresh tokens
- [x] Controller tests: nonce present/absent in ID tokens based on whether it was in the auth request
- [x] End-to-end flow tests: auto-approve path, refresh grant §12.2 compliance, refresh grant no-nonce case
- [x] Full suite: 1799 tests, 0 failures

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)