### PR TITLE
feat(test): implement AuthifyTest.OAuthClient protocol client simulator

### DIFF
--- a/test/protocol_clients/oauth_client_integration_test.exs
+++ b/test/protocol_clients/oauth_client_integration_test.exs
@@ -1,0 +1,70 @@
+defmodule AuthifyTest.OAuthClientIntegrationTest do
+  @moduledoc """
+  End-to-end integration test for AuthifyTest.OAuthClient.
+
+  This test exercises the complete authorization code + PKCE flow using OAuthClient
+  to simulate a conformant OAuth2/OIDC relying party. It catches a class of bugs
+  that the existing server-only tests miss:
+
+  - ID token signature bugs (server could produce a token signed with the wrong
+    key or using the wrong algorithm — server tests never call :public_key.verify/4)
+  - PKCE enforcement gaps (wrong verifier accepted — server tests assert on HTTP
+    status but not on whether PKCE was actually validated)
+  - Scope/claim mismatches (userinfo returning wrong claims for a given scope set)
+  - Nonce round-trip failures (server omitting the nonce claim from the ID token)
+  - Refresh token producing a valid new access token (not just a 200 response)
+  """
+
+  use AuthifyWeb.ConnCase, async: true
+
+  alias AuthifyTest.OAuthClient
+
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
+  @tag :capture_log
+  test "complete authorization code + PKCE flow with client-side ID token validation" do
+    org = organization_fixture()
+    app = application_fixture(organization: org)
+    user = user_for_organization_fixture(org)
+
+    client = OAuthClient.new(build_conn(), app, org)
+
+    # Step 1: Authorization code + PKCE flow
+    assert {:ok, {conn, code, verifier, nonce}} =
+             OAuthClient.authorize(client, user, scopes: ["openid", "profile", "email"])
+
+    assert is_binary(code)
+    assert is_binary(verifier)
+    assert is_binary(nonce)
+
+    # Step 2: Exchange code for tokens
+    assert {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+    assert is_binary(tokens.access_token)
+    assert is_binary(tokens.id_token)
+    assert is_binary(tokens.refresh_token)
+    assert tokens.token_type == "Bearer"
+
+    # Step 3: Client-side RS256 signature verification + claims validation.
+    # This is the key check that server-only tests do not perform.
+    assert {:ok, claims} = OAuthClient.validate_id_token(client, tokens.id_token, nonce: nonce)
+    assert claims["sub"] == to_string(user.id)
+    assert claims["aud"] == app.client_id
+    assert is_integer(claims["exp"])
+    assert claims["nonce"] == nonce
+
+    # Step 4: Userinfo scope-to-claim mapping
+    assert {:ok, userinfo} = OAuthClient.fetch_userinfo(client, tokens.access_token)
+    assert userinfo["sub"] == to_string(user.id)
+    assert is_binary(userinfo["email"])
+    assert is_binary(userinfo["name"])
+
+    # Step 5: Refresh token grant produces a usable new access token
+    assert {:ok, new_tokens} = OAuthClient.refresh(client, tokens.refresh_token)
+    assert is_binary(new_tokens.access_token)
+    refute new_tokens.access_token == tokens.access_token
+
+    assert {:ok, refreshed_userinfo} = OAuthClient.fetch_userinfo(client, new_tokens.access_token)
+    assert refreshed_userinfo["sub"] == to_string(user.id)
+  end
+end

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -171,6 +171,64 @@ defmodule AuthifyTest.OAuthClientTest do
     end
   end
 
+  describe "refresh/2" do
+    setup do
+      org = organization_fixture()
+      app = application_fixture(organization: org)
+      user = user_for_organization_fixture(org)
+      client = OAuthClient.new(build_conn(), app, org)
+
+      {:ok, {conn, code, verifier, _nonce}} =
+        OAuthClient.authorize(client, user, scopes: ["openid", "profile"])
+
+      {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+
+      %{client: client, tokens: tokens}
+    end
+
+    test "returns a new access token", %{client: client, tokens: tokens} do
+      assert {:ok, new_tokens} = OAuthClient.refresh(client, tokens.refresh_token)
+      assert is_binary(new_tokens.access_token)
+      assert new_tokens.token_type == "Bearer"
+      assert is_integer(new_tokens.expires_in)
+    end
+
+    test "new access token differs from the original", %{client: client, tokens: tokens} do
+      {:ok, new_tokens} = OAuthClient.refresh(client, tokens.refresh_token)
+      refute new_tokens.access_token == tokens.access_token
+    end
+
+    test "returns error for invalid refresh token", %{client: client} do
+      assert {:error, _reason} = OAuthClient.refresh(client, "not-a-valid-refresh-token")
+    end
+  end
+
+  describe "client_credentials/2" do
+    setup do
+      org = organization_fixture()
+      # Management API app required for client_credentials grant
+      app = management_api_application_fixture(organization: org)
+      client = OAuthClient.new(build_conn(), app, org)
+      %{org: org, app: app, client: client}
+    end
+
+    test "returns an access token with correct shape", %{client: client} do
+      assert {:ok, tokens} =
+               OAuthClient.client_credentials(client,
+                 scopes: ["management_app:read", "users:read"]
+               )
+
+      assert is_binary(tokens.access_token)
+      assert tokens.token_type == "Bearer"
+      assert is_integer(tokens.expires_in)
+    end
+
+    test "returns error for scopes not granted to the app", %{client: client} do
+      result = OAuthClient.client_credentials(client, scopes: ["invalid_scope"])
+      assert match?({:error, _}, result)
+    end
+  end
+
   describe "exchange_code/4" do
     setup do
       org = organization_fixture()

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -58,4 +58,46 @@ defmodule AuthifyTest.OAuthClientTest do
       refute nonce1 == nonce2
     end
   end
+
+  describe "exchange_code/4" do
+    setup do
+      org = organization_fixture()
+      app = application_fixture(organization: org)
+      user = user_for_organization_fixture(org)
+      client = OAuthClient.new(build_conn(), app, org)
+
+      {:ok, {conn, code, verifier, nonce}} =
+        OAuthClient.authorize(client, user, scopes: ["openid", "profile", "email"])
+
+      %{
+        org: org,
+        app: app,
+        user: user,
+        client: client,
+        conn: conn,
+        code: code,
+        verifier: verifier,
+        nonce: nonce
+      }
+    end
+
+    test "returns tokens map with all required fields", %{
+      client: client,
+      conn: conn,
+      code: code,
+      verifier: verifier
+    } do
+      assert {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+      assert is_binary(tokens.access_token)
+      assert is_binary(tokens.id_token)
+      assert is_binary(tokens.refresh_token)
+      assert is_integer(tokens.expires_in)
+      assert tokens.token_type == "Bearer"
+    end
+
+    test "server rejects wrong code_verifier", %{client: client, conn: conn, code: code} do
+      wrong_verifier = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+      assert {:error, _reason} = OAuthClient.exchange_code(client, conn, code, wrong_verifier)
+    end
+  end
 end

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -1,6 +1,9 @@
 defmodule AuthifyTest.OAuthClientTest do
   use AuthifyWeb.ConnCase, async: true
 
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
   alias AuthifyTest.OAuthClient
 
   describe "generate_pkce/0" do
@@ -22,6 +25,37 @@ defmodule AuthifyTest.OAuthClientTest do
       {v1, _} = OAuthClient.generate_pkce()
       {v2, _} = OAuthClient.generate_pkce()
       refute v1 == v2
+    end
+  end
+
+  describe "authorize/3" do
+    setup do
+      org = organization_fixture()
+      app = application_fixture(organization: org)
+      user = user_for_organization_fixture(org)
+      %{org: org, app: app, user: user}
+    end
+
+    test "returns code, verifier, and nonce for a fresh user (consent required)", %{
+      org: org,
+      app: app,
+      user: user
+    } do
+      client = OAuthClient.new(build_conn(), app, org)
+
+      assert {:ok, {_conn, code, verifier, nonce}} =
+               OAuthClient.authorize(client, user, scopes: ["openid", "profile", "email"])
+
+      assert is_binary(code) and byte_size(code) > 0
+      assert is_binary(verifier) and byte_size(verifier) > 0
+      assert is_binary(nonce) and byte_size(nonce) > 0
+    end
+
+    test "generates a unique nonce on each call", %{org: org, app: app, user: user} do
+      client = OAuthClient.new(build_conn(), app, org)
+      {:ok, {_, _, _, nonce1}} = OAuthClient.authorize(client, user, scopes: ["openid"])
+      {:ok, {_, _, _, nonce2}} = OAuthClient.authorize(client, user, scopes: ["openid"])
+      refute nonce1 == nonce2
     end
   end
 end

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -134,6 +134,43 @@ defmodule AuthifyTest.OAuthClientTest do
     end
   end
 
+  describe "fetch_userinfo/2" do
+    setup do
+      org = organization_fixture()
+      app = application_fixture(organization: org)
+      user = user_for_organization_fixture(org)
+      client = OAuthClient.new(build_conn(), app, org)
+      %{org: org, app: app, user: user, client: client}
+    end
+
+    test "returns claims when email scope is requested", %{client: client, user: user} do
+      {:ok, {conn, code, verifier, _nonce}} =
+        OAuthClient.authorize(client, user, scopes: ["openid", "profile", "email"])
+
+      {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+
+      assert {:ok, userinfo} = OAuthClient.fetch_userinfo(client, tokens.access_token)
+      assert is_binary(userinfo["sub"])
+      assert is_binary(userinfo["email"])
+      assert is_binary(userinfo["name"])
+    end
+
+    test "email claim is absent when email scope is not requested", %{client: client, user: user} do
+      {:ok, {conn, code, verifier, _nonce}} =
+        OAuthClient.authorize(client, user, scopes: ["openid", "profile"])
+
+      {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+
+      assert {:ok, userinfo} = OAuthClient.fetch_userinfo(client, tokens.access_token)
+      assert is_binary(userinfo["sub"])
+      refute Map.has_key?(userinfo, "email")
+    end
+
+    test "returns error for invalid access token", %{client: client} do
+      assert {:error, _reason} = OAuthClient.fetch_userinfo(client, "not-a-valid-token")
+    end
+  end
+
   describe "exchange_code/4" do
     setup do
       org = organization_fixture()

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -1,4 +1,6 @@
 defmodule AuthifyTest.OAuthClientTest do
+  @moduledoc false
+
   use AuthifyWeb.ConnCase, async: true
 
   import Authify.AccountsFixtures

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -1,0 +1,27 @@
+defmodule AuthifyTest.OAuthClientTest do
+  use AuthifyWeb.ConnCase, async: true
+
+  alias AuthifyTest.OAuthClient
+
+  describe "generate_pkce/0" do
+    test "challenge is SHA-256 of verifier, base64url-encoded without padding" do
+      {verifier, challenge} = OAuthClient.generate_pkce()
+
+      expected_challenge =
+        :crypto.hash(:sha256, verifier) |> Base.url_encode64(padding: false)
+
+      assert challenge == expected_challenge
+      assert byte_size(verifier) > 0
+      assert byte_size(challenge) > 0
+      # No padding characters
+      refute String.contains?(verifier, "=")
+      refute String.contains?(challenge, "=")
+    end
+
+    test "generates unique verifiers on each call" do
+      {v1, _} = OAuthClient.generate_pkce()
+      {v2, _} = OAuthClient.generate_pkce()
+      refute v1 == v2
+    end
+  end
+end

--- a/test/protocol_clients/oauth_client_test.exs
+++ b/test/protocol_clients/oauth_client_test.exs
@@ -61,6 +61,79 @@ defmodule AuthifyTest.OAuthClientTest do
     end
   end
 
+  describe "validate_id_token/3" do
+    setup do
+      org = organization_fixture()
+      app = application_fixture(organization: org)
+      user = user_for_organization_fixture(org)
+      client = OAuthClient.new(build_conn(), app, org)
+
+      {:ok, {conn, code, verifier, nonce}} =
+        OAuthClient.authorize(client, user, scopes: ["openid", "profile", "email"])
+
+      {:ok, tokens} = OAuthClient.exchange_code(client, conn, code, verifier)
+
+      %{org: org, app: app, user: user, client: client, tokens: tokens, nonce: nonce}
+    end
+
+    test "accepts a valid RS256-signed ID token", %{client: client, tokens: tokens, nonce: nonce} do
+      assert {:ok, claims} = OAuthClient.validate_id_token(client, tokens.id_token, nonce: nonce)
+      assert is_map(claims)
+      assert is_binary(claims["sub"])
+      assert is_binary(claims["iss"])
+    end
+
+    test "rejects a tampered signature", %{client: client, tokens: tokens, nonce: nonce} do
+      [header, payload, _sig] = String.split(tokens.id_token, ".")
+      tampered = "#{header}.#{payload}.dGFtcGVyZWQ"
+
+      assert {:error, :invalid_signature} =
+               OAuthClient.validate_id_token(client, tampered, nonce: nonce)
+    end
+
+    test "rejects an expired token", %{org: org, app: app, client: client} do
+      # Sign a token with an exp in the past using the org's actual signing key
+      {:ok, cert} = Authify.Accounts.get_or_generate_oauth_signing_certificate(org)
+      [entry | _] = :public_key.pem_decode(cert.private_key)
+      private_key = :public_key.pem_entry_decode(entry)
+
+      now = System.system_time(:second)
+
+      claims = %{
+        "iss" => "#{AuthifyWeb.Endpoint.url()}/#{org.slug}",
+        "sub" => "1",
+        "aud" => app.client_id,
+        "exp" => now - 3600,
+        "iat" => now - 7200
+      }
+
+      header = %{"alg" => "RS256", "typ" => "JWT", "kid" => to_string(cert.id)}
+      encoded_header = Base.url_encode64(Jason.encode!(header), padding: false)
+      encoded_claims = Base.url_encode64(Jason.encode!(claims), padding: false)
+      signing_input = "#{encoded_header}.#{encoded_claims}"
+      signature = :public_key.sign(signing_input, :sha256, private_key)
+      expired_token = "#{signing_input}.#{Base.url_encode64(signature, padding: false)}"
+
+      assert {:error, :expired} = OAuthClient.validate_id_token(client, expired_token)
+    end
+
+    test "rejects wrong audience", %{org: org, tokens: tokens, nonce: nonce} do
+      # Create a second app; its client_id won't match the token's aud claim
+      app2 = application_fixture(organization: org)
+      client2 = OAuthClient.new(build_conn(), app2, org)
+
+      assert {:error, :wrong_audience} =
+               OAuthClient.validate_id_token(client2, tokens.id_token, nonce: nonce)
+    end
+
+    test "rejects nonce mismatch", %{client: client, tokens: tokens} do
+      assert {:error, :nonce_mismatch} =
+               OAuthClient.validate_id_token(client, tokens.id_token,
+                 nonce: "definitely-wrong-nonce"
+               )
+    end
+  end
+
   describe "exchange_code/4" do
     setup do
       org = organization_fixture()

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -127,6 +127,70 @@ defmodule AuthifyTest.OAuthClient do
     end
   end
 
+  def refresh(%__MODULE__{app: app, org: org}, refresh_token) do
+    params = %{
+      "grant_type" => "refresh_token",
+      "client_id" => app.client_id,
+      "client_secret" => app.client_secret,
+      "refresh_token" => refresh_token
+    }
+
+    resp = post(build_conn(), "/#{org.slug}/oauth/token", params)
+
+    case resp.status do
+      200 ->
+        body = Jason.decode!(resp.resp_body)
+
+        if body["access_token"] && body["token_type"] == "Bearer" do
+          {:ok,
+           %{
+             access_token: body["access_token"],
+             id_token: body["id_token"],
+             refresh_token: body["refresh_token"],
+             expires_in: body["expires_in"],
+             token_type: body["token_type"]
+           }}
+        else
+          {:error, {:invalid_refresh_response, body}}
+        end
+
+      _status ->
+        {:error, {:refresh_failed, Jason.decode!(resp.resp_body)}}
+    end
+  end
+
+  def client_credentials(%__MODULE__{app: app, org: org}, opts \\ []) do
+    scopes = Keyword.get(opts, :scopes, [])
+
+    params = %{
+      "grant_type" => "client_credentials",
+      "client_id" => app.client_id,
+      "client_secret" => app.client_secret,
+      "scope" => Enum.join(scopes, " ")
+    }
+
+    resp = post(build_conn(), "/#{org.slug}/oauth/token", params)
+
+    case resp.status do
+      200 ->
+        body = Jason.decode!(resp.resp_body)
+
+        if body["access_token"] && body["token_type"] == "Bearer" do
+          {:ok,
+           %{
+             access_token: body["access_token"],
+             token_type: body["token_type"],
+             expires_in: body["expires_in"]
+           }}
+        else
+          {:error, {:invalid_response, body}}
+        end
+
+      _status ->
+        {:error, {:client_credentials_failed, Jason.decode!(resp.resp_body)}}
+    end
+  end
+
   def validate_id_token(%__MODULE__{app: app, org: org}, id_token, opts \\ []) do
     expected_nonce = Keyword.get(opts, :nonce)
 

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -69,6 +69,52 @@ defmodule AuthifyTest.OAuthClient do
     {:error, {:unexpected_status, status}}
   end
 
+  def exchange_code(%__MODULE__{app: app, org: org}, _conn, code, verifier) do
+    params = %{
+      "grant_type" => "authorization_code",
+      "client_id" => app.client_id,
+      "client_secret" => app.client_secret,
+      "code" => code,
+      "redirect_uri" => first_redirect_uri(app),
+      "code_verifier" => verifier
+    }
+
+    resp = post(build_conn(), "/#{org.slug}/oauth/token", params)
+
+    case resp.status do
+      200 ->
+        body = Jason.decode!(resp.resp_body)
+        validate_token_response(body)
+
+      _status ->
+        body = Jason.decode!(resp.resp_body)
+        {:error, {:token_exchange_failed, body}}
+    end
+  end
+
+  defp validate_token_response(body) do
+    required = ["access_token", "token_type", "expires_in"]
+    missing = Enum.reject(required, &Map.has_key?(body, &1))
+
+    cond do
+      missing != [] ->
+        {:error, {:missing_fields, missing}}
+
+      body["token_type"] != "Bearer" ->
+        {:error, {:wrong_token_type, body["token_type"]}}
+
+      true ->
+        {:ok,
+         %{
+           access_token: body["access_token"],
+           id_token: body["id_token"],
+           refresh_token: body["refresh_token"],
+           expires_in: body["expires_in"],
+           token_type: body["token_type"]
+         }}
+    end
+  end
+
   defp first_redirect_uri(app) do
     app.redirect_uris
     |> String.split("\n")

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -139,20 +139,7 @@ defmodule AuthifyTest.OAuthClient do
 
     case resp.status do
       200 ->
-        body = Jason.decode!(resp.resp_body)
-
-        if body["access_token"] && body["token_type"] == "Bearer" do
-          {:ok,
-           %{
-             access_token: body["access_token"],
-             id_token: body["id_token"],
-             refresh_token: body["refresh_token"],
-             expires_in: body["expires_in"],
-             token_type: body["token_type"]
-           }}
-        else
-          {:error, {:invalid_refresh_response, body}}
-        end
+        resp.resp_body |> Jason.decode!() |> validate_token_response()
 
       _status ->
         {:error, {:refresh_failed, Jason.decode!(resp.resp_body)}}
@@ -162,12 +149,16 @@ defmodule AuthifyTest.OAuthClient do
   def client_credentials(%__MODULE__{app: app, org: org}, opts \\ []) do
     scopes = Keyword.get(opts, :scopes, [])
 
-    params = %{
+    base_params = %{
       "grant_type" => "client_credentials",
       "client_id" => app.client_id,
-      "client_secret" => app.client_secret,
-      "scope" => Enum.join(scopes, " ")
+      "client_secret" => app.client_secret
     }
+
+    params =
+      if scopes == [],
+        do: base_params,
+        else: Map.put(base_params, "scope", Enum.join(scopes, " "))
 
     resp = post(build_conn(), "/#{org.slug}/oauth/token", params)
 

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -164,18 +164,7 @@ defmodule AuthifyTest.OAuthClient do
 
     case resp.status do
       200 ->
-        body = Jason.decode!(resp.resp_body)
-
-        if body["access_token"] && body["token_type"] == "Bearer" do
-          {:ok,
-           %{
-             access_token: body["access_token"],
-             token_type: body["token_type"],
-             expires_in: body["expires_in"]
-           }}
-        else
-          {:error, {:invalid_response, body}}
-        end
+        resp.resp_body |> Jason.decode!() |> validate_token_response()
 
       _status ->
         {:error, {:client_credentials_failed, Jason.decode!(resp.resp_body)}}
@@ -187,6 +176,7 @@ defmodule AuthifyTest.OAuthClient do
 
     with {:ok, {header_b64, payload_b64, sig_b64}} <- split_jwt(id_token),
          {:ok, header} <- decode_json_b64(header_b64),
+         :ok <- verify_alg(header["alg"]),
          {:ok, claims} <- decode_json_b64(payload_b64),
          {:ok, signature} <- Base.url_decode64(sig_b64, padding: false),
          {:ok, public_key} <- fetch_signing_key(org, header["kid"]),
@@ -195,6 +185,9 @@ defmodule AuthifyTest.OAuthClient do
       {:ok, claims}
     end
   end
+
+  defp verify_alg("RS256"), do: :ok
+  defp verify_alg(alg), do: {:error, {:unsupported_alg, alg}}
 
   defp split_jwt(token) do
     case String.split(token, ".") do

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -1,0 +1,30 @@
+defmodule AuthifyTest.OAuthClient do
+  @moduledoc false
+
+  @endpoint AuthifyWeb.Endpoint
+
+  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
+  import Phoenix.ConnTest
+  import AuthifyWeb.ConnCase, only: [log_in_user: 2]
+
+  defstruct [:conn, :app, :org]
+
+  def new(conn, app, org), do: %__MODULE__{conn: conn, app: app, org: org}
+
+  def generate_pkce do
+    verifier = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
+    challenge = Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
+    {verifier, challenge}
+  end
+
+  # Placeholder to suppress unused-import warnings until subsequent tasks
+  # implement HTTP helpers that use these imports.
+  @doc false
+  def __imports_used__ do
+    conn = build_conn()
+    conn = put_req_header(conn, "accept", "application/json")
+    _headers = get_resp_header(conn, "location")
+    _client = log_in_user(conn, %{})
+    @endpoint
+  end
+end

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -1,12 +1,6 @@
 defmodule AuthifyTest.OAuthClient do
   @moduledoc false
 
-  @endpoint AuthifyWeb.Endpoint
-
-  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
-  import Phoenix.ConnTest
-  import AuthifyWeb.ConnCase, only: [log_in_user: 2]
-
   defstruct [:conn, :app, :org]
 
   def new(conn, app, org), do: %__MODULE__{conn: conn, app: app, org: org}
@@ -15,16 +9,5 @@ defmodule AuthifyTest.OAuthClient do
     verifier = Base.url_encode64(:crypto.strong_rand_bytes(32), padding: false)
     challenge = Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
     {verifier, challenge}
-  end
-
-  # Placeholder to suppress unused-import warnings until subsequent tasks
-  # implement HTTP helpers that use these imports.
-  @doc false
-  def __imports_used__ do
-    conn = build_conn()
-    conn = put_req_header(conn, "accept", "application/json")
-    _headers = get_resp_header(conn, "location")
-    _client = log_in_user(conn, %{})
-    @endpoint
   end
 end

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -1,6 +1,12 @@
 defmodule AuthifyTest.OAuthClient do
   @moduledoc false
 
+  @endpoint AuthifyWeb.Endpoint
+
+  import Plug.Conn, only: [get_resp_header: 2]
+  import Phoenix.ConnTest
+  import AuthifyWeb.ConnCase, only: [log_in_user: 2]
+
   defstruct [:conn, :app, :org]
 
   def new(conn, app, org), do: %__MODULE__{conn: conn, app: app, org: org}
@@ -10,4 +16,75 @@ defmodule AuthifyTest.OAuthClient do
     challenge = Base.url_encode64(:crypto.hash(:sha256, verifier), padding: false)
     {verifier, challenge}
   end
+
+  def authorize(%__MODULE__{app: app, org: org}, user, opts \\ []) do
+    scopes = Keyword.get(opts, :scopes, ["openid"])
+    state = Keyword.get(opts, :state, Base.encode16(:crypto.strong_rand_bytes(8), case: :lower))
+    {verifier, challenge} = generate_pkce()
+    nonce = Base.url_encode64(:crypto.strong_rand_bytes(16), padding: false)
+
+    params = build_authorize_params(app, scopes, state, challenge, nonce)
+
+    auth_conn = log_in_user(build_conn(), user)
+    resp = get(auth_conn, "/#{org.slug}/oauth/authorize", params)
+
+    handle_authorize_response(resp, org, user, params, verifier, nonce)
+  end
+
+  defp build_authorize_params(app, scopes, state, challenge, nonce) do
+    %{
+      "client_id" => app.client_id,
+      "redirect_uri" => first_redirect_uri(app),
+      "response_type" => "code",
+      "scope" => Enum.join(scopes, " "),
+      "state" => state,
+      "code_challenge" => challenge,
+      "code_challenge_method" => "S256",
+      "nonce" => nonce
+    }
+  end
+
+  defp handle_authorize_response(%{status: 302} = resp, _org, _user, _params, verifier, nonce) do
+    location = resp |> get_resp_header("location") |> List.first()
+
+    case extract_code(location) do
+      {:ok, code} -> {:ok, {resp, code, verifier, nonce}}
+      err -> err
+    end
+  end
+
+  defp handle_authorize_response(%{status: 200}, org, user, params, verifier, nonce) do
+    consent_conn = log_in_user(build_conn(), user)
+    consent_params = Map.put(params, "approve", "true")
+    consent_resp = post(consent_conn, "/#{org.slug}/oauth/consent", consent_params)
+    location = consent_resp |> get_resp_header("location") |> List.first()
+
+    case extract_code(location) do
+      {:ok, code} -> {:ok, {consent_resp, code, verifier, nonce}}
+      err -> err
+    end
+  end
+
+  defp handle_authorize_response(%{status: status}, _org, _user, _params, _verifier, _nonce) do
+    {:error, {:unexpected_status, status}}
+  end
+
+  defp first_redirect_uri(app) do
+    app.redirect_uris
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> List.first()
+  end
+
+  defp extract_code(url) when is_binary(url) do
+    params = url |> URI.parse() |> Map.get(:query, "") |> URI.decode_query()
+
+    case Map.get(params, "code") do
+      nil -> {:error, :no_code_in_redirect}
+      code -> {:ok, code}
+    end
+  end
+
+  defp extract_code(_), do: {:error, :no_redirect_url}
 end

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -115,6 +115,93 @@ defmodule AuthifyTest.OAuthClient do
     end
   end
 
+  def validate_id_token(%__MODULE__{app: app, org: org}, id_token, opts \\ []) do
+    expected_nonce = Keyword.get(opts, :nonce)
+
+    with {:ok, {header_b64, payload_b64, sig_b64}} <- split_jwt(id_token),
+         {:ok, header} <- decode_json_b64(header_b64),
+         {:ok, claims} <- decode_json_b64(payload_b64),
+         {:ok, signature} <- Base.url_decode64(sig_b64, padding: false),
+         {:ok, public_key} <- fetch_signing_key(org, header["kid"]),
+         :ok <- verify_signature("#{header_b64}.#{payload_b64}", signature, public_key),
+         :ok <- validate_claims(claims, app, org, expected_nonce) do
+      {:ok, claims}
+    end
+  end
+
+  defp split_jwt(token) do
+    case String.split(token, ".") do
+      [h, p, s] -> {:ok, {h, p, s}}
+      _ -> {:error, :invalid_jwt_format}
+    end
+  end
+
+  defp decode_json_b64(b64) do
+    with {:ok, json} <- Base.url_decode64(b64, padding: false),
+         {:ok, decoded} <- Jason.decode(json) do
+      {:ok, decoded}
+    else
+      _ -> {:error, :jwt_decode_failed}
+    end
+  end
+
+  defp fetch_signing_key(org, kid) do
+    discovery_resp = get(build_conn(), "/#{org.slug}/.well-known/openid-configuration")
+    discovery = Jason.decode!(discovery_resp.resp_body)
+
+    base_url = AuthifyWeb.Endpoint.url()
+    jwks_path = String.replace_prefix(discovery["jwks_uri"], base_url, "")
+
+    jwks_resp = get(build_conn(), jwks_path)
+    keys = Jason.decode!(jwks_resp.resp_body)["keys"] || []
+
+    key = Enum.find(keys, List.first(keys), &(&1["kid"] == kid))
+
+    if key, do: parse_rsa_public_key(key), else: {:error, :no_signing_key}
+  end
+
+  defp parse_rsa_public_key(%{"n" => n_b64, "e" => e_b64}) do
+    with {:ok, n_bin} <- Base.url_decode64(n_b64, padding: false),
+         {:ok, e_bin} <- Base.url_decode64(e_b64, padding: false) do
+      {:ok, {:RSAPublicKey, :binary.decode_unsigned(n_bin), :binary.decode_unsigned(e_bin)}}
+    else
+      _ -> {:error, :invalid_jwk}
+    end
+  end
+
+  defp verify_signature(signing_input, signature, public_key) do
+    if :public_key.verify(signing_input, :sha256, signature, public_key) do
+      :ok
+    else
+      {:error, :invalid_signature}
+    end
+  end
+
+  defp validate_claims(claims, app, org, expected_nonce) do
+    expected_iss = "#{AuthifyWeb.Endpoint.url()}/#{org.slug}"
+    now = System.system_time(:second)
+
+    cond do
+      claims["iss"] != expected_iss ->
+        {:error, :wrong_issuer}
+
+      claims["aud"] != app.client_id ->
+        {:error, :wrong_audience}
+
+      is_nil(claims["exp"]) or claims["exp"] <= now ->
+        {:error, :expired}
+
+      is_nil(claims["iat"]) ->
+        {:error, :missing_iat}
+
+      not is_nil(expected_nonce) and claims["nonce"] != expected_nonce ->
+        {:error, :nonce_mismatch}
+
+      true ->
+        :ok
+    end
+  end
+
   defp first_redirect_uri(app) do
     app.redirect_uris
     |> String.split("\n")

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -3,7 +3,7 @@ defmodule AuthifyTest.OAuthClient do
 
   @endpoint AuthifyWeb.Endpoint
 
-  import Plug.Conn, only: [get_resp_header: 2]
+  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
   import Phoenix.ConnTest
   import AuthifyWeb.ConnCase, only: [log_in_user: 2]
 
@@ -112,6 +112,18 @@ defmodule AuthifyTest.OAuthClient do
            expires_in: body["expires_in"],
            token_type: body["token_type"]
          }}
+    end
+  end
+
+  def fetch_userinfo(%__MODULE__{org: org}, access_token) do
+    resp =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{access_token}")
+      |> get("/#{org.slug}/oauth/userinfo")
+
+    case resp.status do
+      200 -> {:ok, Jason.decode!(resp.resp_body)}
+      _status -> {:error, {:userinfo_failed, resp.status}}
     end
   end
 


### PR DESCRIPTION
Resolves #72

## Summary

- Implements `AuthifyTest.OAuthClient` — an in-process OAuth2/OIDC relying party simulator that exercises both sides of the protocol with real crypto
- Adds 19 unit/behavioral tests and 1 end-to-end integration test (20 total, all `async: true`)
- Catches a class of bugs that server-only tests miss: ID token signature issues, PKCE enforcement gaps, scope/claim mismatches, nonce round-trips, and refresh token usability

## What's implemented

**`test/support/protocol_clients/oauth_client.ex`**
- `new/3`, `generate_pkce/0` — struct constructor and PKCE helper
- `authorize/3` — full auth code flow with transparent consent handling; returns `{conn, code, verifier, nonce}`
- `exchange_code/4` — token exchange with PKCE verifier
- `validate_id_token/3` — RS256 signature verification via JWKS discovery + claims validation (`iss`, `aud`, `exp`, `iat`, `nonce`, `alg`)
- `fetch_userinfo/2` — Bearer auth GET to userinfo endpoint
- `refresh/2` — refresh token grant
- `client_credentials/2` — client credentials grant (for Management API flows)

**`test/protocol_clients/oauth_client_test.exs`** — 19 tests covering:
- PKCE challenge derivation correctness
- Authorization flow and nonce uniqueness
- Token exchange and wrong-verifier rejection
- RS256 signature validation (valid, tampered, expired, wrong audience, nonce mismatch)
- Userinfo scope gating (email absent when email scope not requested)
- Refresh token produces new usable access token
- Client credentials token shape and invalid scope rejection

**`test/protocol_clients/oauth_client_integration_test.exs`** — 1 end-to-end test covering the full authorization code + PKCE flow: authorize → exchange → client-side RS256 validation → userinfo → refresh

## Test plan

- [x] `mix test test/protocol_clients/` → 20 tests, 0 failures
- [x] `mix test` → full suite passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)