### PR TITLE
refactor: consolidate filtering/sorting into FilterSort and expand its API

### DIFF
--- a/lib/authify/filter_sort.ex
+++ b/lib/authify/filter_sort.ex
@@ -22,14 +22,17 @@ defmodule Authify.FilterSort do
       iex> apply_sort(User, "name", "asc", [:name, :email])
       #Ecto.Query<...>
   """
-  def apply_sort(query, sort_field, order \\ "asc", allowed_fields) do
+  def apply_sort(query, sort_field, order \\ "asc", allowed_fields, opts \\ []) do
     field_atom = normalize_field(sort_field)
     order_atom = normalize_order(order)
 
     if field_atom in allowed_fields do
       order_by(query, ^[{order_atom, field_atom}])
     else
-      query
+      case Keyword.get(opts, :default) do
+        nil -> query
+        default_sort -> order_by(query, ^default_sort)
+      end
     end
   end
 
@@ -52,6 +55,34 @@ defmodule Authify.FilterSort do
   def apply_text_filter(query, field, search_term) when is_binary(search_term) do
     search_pattern = "%#{search_term}%"
     where(query, [q], like(field(q, ^field), ^search_pattern))
+  end
+
+  @doc """
+  Applies text search filtering across multiple fields using OR semantics.
+
+  ## Parameters
+    * `query` - The Ecto query to filter
+    * `fields` - List of fields to search across
+    * `search_term` - The text to search for (uses LIKE)
+
+  ## Examples
+
+      iex> apply_multi_text_filter(ServiceProvider, [:entity_id, :acs_url], "example")
+      #Ecto.Query<...>
+  """
+  def apply_multi_text_filter(query, _fields, nil), do: query
+  def apply_multi_text_filter(query, _fields, ""), do: query
+
+  def apply_multi_text_filter(query, fields, search_term)
+      when is_binary(search_term) and is_list(fields) do
+    search_pattern = "%#{search_term}%"
+
+    condition =
+      Enum.reduce(fields, dynamic(false), fn field, acc ->
+        dynamic([q], ^acc or like(field(q, ^field), ^search_pattern))
+      end)
+
+    where(query, ^condition)
   end
 
   @doc """

--- a/lib/authify/saml.ex
+++ b/lib/authify/saml.ex
@@ -34,16 +34,15 @@ defmodule Authify.SAML do
       iex> list_service_providers_filtered(org, sort: :entity_id, order: :asc, search: "app")
       [%ServiceProvider{}, ...]
   """
-  def list_service_providers_filtered(%Organization{id: org_id}, opts \\ []) do
-    query =
-      from(sp in ServiceProvider,
-        where: sp.organization_id == ^org_id
-      )
+  @saml_sp_sort_fields [:entity_id, :acs_url, :inserted_at, :updated_at]
 
-    query
+  def list_service_providers_filtered(%Organization{id: org_id}, opts \\ []) do
+    from(sp in ServiceProvider, where: sp.organization_id == ^org_id)
     |> apply_saml_provider_filters(opts)
-    |> apply_saml_provider_search(opts[:search])
-    |> apply_saml_provider_sorting(opts[:sort], opts[:order])
+    |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], opts[:search])
+    |> FilterSort.apply_sort(opts[:sort], to_string(opts[:order]), @saml_sp_sort_fields,
+      default: [desc: :inserted_at]
+    )
     |> Repo.all()
   end
 
@@ -73,29 +72,6 @@ defmodule Authify.SAML do
 
   defp maybe_filter_saml_provider_by_status(query, _),
     do: where(query, [sp], sp.is_active == true)
-
-  defp apply_saml_provider_search(query, nil), do: query
-  defp apply_saml_provider_search(query, ""), do: query
-
-  defp apply_saml_provider_search(query, search_term) when is_binary(search_term) do
-    search_pattern = "%#{search_term}%"
-
-    where(
-      query,
-      [sp],
-      like(sp.entity_id, ^search_pattern) or like(sp.acs_url, ^search_pattern)
-    )
-  end
-
-  @saml_sp_sort_fields [:entity_id, :acs_url, :inserted_at, :updated_at]
-
-  defp apply_saml_provider_sorting(query, sort_field, order) do
-    if sort_field in @saml_sp_sort_fields do
-      FilterSort.apply_sort(query, sort_field, to_string(order), @saml_sp_sort_fields)
-    else
-      order_by(query, [sp], desc: sp.inserted_at)
-    end
-  end
 
   @doc """
   Returns a paginated list of service providers for an organization.

--- a/lib/authify/saml.ex
+++ b/lib/authify/saml.ex
@@ -4,6 +4,7 @@ defmodule Authify.SAML do
   """
 
   import Ecto.Query, warn: false
+  alias Authify.FilterSort
   alias Authify.Repo
 
   alias Authify.Accounts.{Organization, User}
@@ -86,19 +87,15 @@ defmodule Authify.SAML do
     )
   end
 
-  defp apply_saml_provider_sorting(query, nil, _),
-    do: order_by(query, [sp], desc: sp.inserted_at)
+  @saml_sp_sort_fields [:entity_id, :acs_url, :inserted_at, :updated_at]
 
-  defp apply_saml_provider_sorting(query, "", _), do: order_by(query, [sp], desc: sp.inserted_at)
-
-  defp apply_saml_provider_sorting(query, sort_field, order)
-       when sort_field in [:entity_id, :acs_url, :inserted_at, :updated_at] do
-    order_atom = if order == :asc or order == "asc", do: :asc, else: :desc
-    order_by(query, [sp], ^[{order_atom, sort_field}])
+  defp apply_saml_provider_sorting(query, sort_field, order) do
+    if sort_field in @saml_sp_sort_fields do
+      FilterSort.apply_sort(query, sort_field, to_string(order), @saml_sp_sort_fields)
+    else
+      order_by(query, [sp], desc: sp.inserted_at)
+    end
   end
-
-  defp apply_saml_provider_sorting(query, _sort_field, _order),
-    do: order_by(query, [sp], desc: sp.inserted_at)
 
   @doc """
   Returns a paginated list of service providers for an organization.

--- a/lib/authify/tasks.ex
+++ b/lib/authify/tasks.ex
@@ -6,6 +6,7 @@ defmodule Authify.Tasks do
 
   import Ecto.Query, warn: false
 
+  alias Authify.FilterSort
   alias Authify.Repo
   alias Authify.Tasks.{BasicTask, StateMachine, Task, TaskLog}
   alias Authify.Tasks.Telemetry, as: TaskTelemetry
@@ -289,8 +290,8 @@ defmodule Authify.Tasks do
   defp apply_task_filters(query, opts) do
     query
     |> filter_by_status(opts[:status])
-    |> filter_by_type(opts[:type])
-    |> filter_by_action(opts[:action])
+    |> FilterSort.apply_exact_filter(:type, opts[:type])
+    |> FilterSort.apply_exact_filter(:action, opts[:action])
   end
 
   defp filter_by_status(query, nil), do: query
@@ -301,18 +302,6 @@ defmodule Authify.Tasks do
 
   defp filter_by_status(query, statuses) when is_list(statuses) do
     where(query, [t], t.status in ^statuses)
-  end
-
-  defp filter_by_type(query, nil), do: query
-
-  defp filter_by_type(query, type) when is_binary(type) do
-    where(query, [t], t.type == ^type)
-  end
-
-  defp filter_by_action(query, nil), do: query
-
-  defp filter_by_action(query, action) when is_binary(action) do
-    where(query, [t], t.action == ^action)
   end
 
   defp apply_organization_filter(query, nil), do: query

--- a/test/authify/filter_sort_test.exs
+++ b/test/authify/filter_sort_test.exs
@@ -1,0 +1,153 @@
+defmodule Authify.FilterSortTest do
+  use Authify.DataCase, async: true
+
+  import Ecto.Query
+  import Authify.AccountsFixtures
+  import Authify.SAMLFixtures
+
+  alias Authify.FilterSort
+  alias Authify.Repo
+  alias Authify.SAML.ServiceProvider
+
+  defp sp_fixture(org, overrides \\ []) do
+    defaults = [organization: org, entity_id: "https://sp-#{System.unique_integer()}.example.com"]
+    service_provider_fixture(Keyword.merge(defaults, overrides))
+  end
+
+  describe "apply_multi_text_filter/3" do
+    test "returns query unchanged when search_term is nil" do
+      org = organization_fixture()
+      sp = sp_fixture(org)
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], nil)
+        |> Repo.all()
+
+      assert Enum.any?(results, &(&1.id == sp.id))
+    end
+
+    test "returns query unchanged when search_term is empty string" do
+      org = organization_fixture()
+      sp = sp_fixture(org)
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], "")
+        |> Repo.all()
+
+      assert Enum.any?(results, &(&1.id == sp.id))
+    end
+
+    test "matches records where the first field contains the search term" do
+      org = organization_fixture()
+      match = sp_fixture(org, entity_id: "https://findme.example.com")
+      no_match = sp_fixture(org, entity_id: "https://other.example.com")
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], "findme")
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert match.id in ids
+      refute no_match.id in ids
+    end
+
+    test "matches records where the second field contains the search term" do
+      org = organization_fixture()
+      match = sp_fixture(org, acs_url: "https://findme.example.com/acs")
+      no_match = sp_fixture(org, acs_url: "https://other.example.com/acs")
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], "findme")
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert match.id in ids
+      refute no_match.id in ids
+    end
+
+    test "matches records that satisfy any field (OR semantics)" do
+      org = organization_fixture()
+      entity_match = sp_fixture(org, entity_id: "https://findme.example.com")
+      acs_match = sp_fixture(org, acs_url: "https://findme.example.com/acs")
+      no_match = sp_fixture(org)
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_multi_text_filter([:entity_id, :acs_url], "findme")
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert entity_match.id in ids
+      assert acs_match.id in ids
+      refute no_match.id in ids
+    end
+  end
+
+  describe "apply_sort/5 with default option" do
+    test "applies default sort when sort_field is nil" do
+      org = organization_fixture()
+      first = sp_fixture(org)
+      second = sp_fixture(org)
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_sort(nil, "asc", [:entity_id], default: [desc: :id])
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert Enum.find_index(ids, &(&1 == second.id)) < Enum.find_index(ids, &(&1 == first.id))
+    end
+
+    test "applies default sort when sort_field is not in allowed_fields" do
+      org = organization_fixture()
+      first = sp_fixture(org)
+      second = sp_fixture(org)
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_sort(:bad_field, "asc", [:entity_id], default: [desc: :id])
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert Enum.find_index(ids, &(&1 == second.id)) < Enum.find_index(ids, &(&1 == first.id))
+    end
+
+    test "ignores default when sort_field is valid" do
+      org = organization_fixture()
+      sp_a = sp_fixture(org, entity_id: "https://aaa.example.com")
+      sp_z = sp_fixture(org, entity_id: "https://zzz.example.com")
+
+      results =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+        |> FilterSort.apply_sort(:entity_id, "asc", [:entity_id], default: [desc: :inserted_at])
+        |> Repo.all()
+
+      ids = Enum.map(results, & &1.id)
+      assert Enum.find_index(ids, &(&1 == sp_a.id)) < Enum.find_index(ids, &(&1 == sp_z.id))
+    end
+
+    test "returns unchanged query when field is invalid and no default is given (backward compat)" do
+      org = organization_fixture()
+      sp_fixture(org)
+
+      base =
+        ServiceProvider
+        |> where([s], s.organization_id == ^org.id)
+
+      result = FilterSort.apply_sort(base, nil, "asc", [:entity_id])
+      assert result == base
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Replaces hand-rolled sorting in `Authify.SAML` and exact-match filters in `Authify.Tasks` with calls to the existing `Authify.FilterSort` helpers
- Extends `FilterSort` with two new general-purpose functions to cover the remaining gaps

## Changes

**Commit 1 — easy wins (no API changes)**
- `Authify.SAML`: replaced 4-clause `apply_saml_provider_sorting/3` with `FilterSort.apply_sort/4`
- `Authify.Tasks`: deleted `filter_by_type/2` and `filter_by_action/2`, replaced with `FilterSort.apply_exact_filter/3` inline

**Commit 2 — FilterSort API expansion**
- `apply_multi_text_filter/3`: OR-based LIKE search across a list of fields; replaces SAML's hardcoded two-field search
- `apply_sort/5`: adds an optional `default:` keyword argument for a fallback `order_by` when the sort field is nil or not in the allowlist; removes the `if/else` wrapper that was left in SAML after commit 1
- Adds `test/authify/filter_sort_test.exs` with 9 tests covering both new functions

## What was intentionally left alone

- `maybe_filter_saml_provider_by_status/2` — SAML-specific semantics (defaults to `is_active == true` on nil, handles `"all"` passthrough); doesn't belong in a generic module
- `filter_by_status/2` in Tasks — handles atom and list-of-atoms inputs that `apply_exact_filter` doesn't cover

## Test plan

- [x] `mix test test/authify/filter_sort_test.exs` — 9 new tests, all green
- [x] `mix test test/authify/saml_test.exs test/authify/tasks_test.exs` — 74 existing tests, all green
- [x] `mix test` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)