### PR TITLE
feat(saml): add SAMLServiceProvider test client with E2E SSO/SLO integration tests

### DIFF
--- a/lib/authify/saml.ex
+++ b/lib/authify/saml.ex
@@ -361,9 +361,17 @@ defmodule Authify.SAML do
 
   @doc """
   Generates a SAML response with assertion.
+
+  Options:
+  - `:sign` — when true, signs the response assertion if a signing certificate is available
   """
-  def generate_saml_response(%Session{} = session, %ServiceProvider{} = sp, %User{} = user) do
-    Authify.SAML.XML.generate_saml_response(session, sp, user)
+  def generate_saml_response(
+        %Session{} = session,
+        %ServiceProvider{} = sp,
+        %User{} = user,
+        options \\ []
+      ) do
+    Authify.SAML.XML.generate_saml_response(session, sp, user, options)
   end
 
   @doc """

--- a/lib/authify_web/controllers/saml_controller.ex
+++ b/lib/authify_web/controllers/saml_controller.ex
@@ -252,7 +252,7 @@ defmodule AuthifyWeb.SAMLController do
     # Preload groups for SAML attribute generation
     user = Authify.Repo.preload(user, :groups)
 
-    case SAML.generate_saml_response(saml_session, service_provider, user) do
+    case SAML.generate_saml_response(saml_session, service_provider, user, sign: true) do
       {:ok, saml_response} ->
         # Encode the SAML response
         encoded_response = Base.encode64(saml_response)

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -48,4 +48,51 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
       assert String.contains?(sp.sp_record.certificate, "BEGIN CERTIFICATE")
     end
   end
+
+  describe "build_authn_request/1" do
+    setup do: %{org: organization_fixture()}
+
+    test "returns a Base64-encoded XML string and a request ID", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert {:ok, {encoded, request_id}} = SAMLServiceProvider.build_authn_request(sp)
+      assert is_binary(encoded)
+      assert is_binary(request_id) and String.starts_with?(request_id, "_")
+      xml = Base.decode64!(encoded)
+      assert String.contains?(xml, "<?xml")
+      assert String.contains?(xml, "<saml2p:AuthnRequest")
+    end
+
+    test "XML contains required SAML AuthnRequest elements", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      {:ok, {encoded, request_id}} = SAMLServiceProvider.build_authn_request(sp)
+      xml = Base.decode64!(encoded)
+
+      assert String.contains?(xml, request_id)
+      assert String.contains?(xml, "IssueInstant")
+      assert String.contains?(xml, sp.entity_id)
+      assert String.contains?(xml, sp.acs_url)
+      assert String.contains?(xml, "AuthnRequest")
+    end
+
+    test "AuthnRequest contains a ds:Signature element", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      {:ok, {encoded, _}} = SAMLServiceProvider.build_authn_request(sp)
+      xml = Base.decode64!(encoded)
+
+      assert String.contains?(xml, "<ds:Signature")
+      assert String.contains?(xml, "<ds:SignatureValue>")
+      assert String.contains?(xml, "<ds:DigestValue>")
+    end
+
+    test "SignatureValue is valid RSA-SHA256 base64 of correct length", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      {:ok, {encoded, _}} = SAMLServiceProvider.build_authn_request(sp)
+      xml = Base.decode64!(encoded)
+
+      [_, sig_b64] = Regex.run(~r/<ds:SignatureValue>([\s\S]*?)<\/ds:SignatureValue>/, xml)
+      assert {:ok, sig_bytes} = Base.decode64(String.trim(sig_b64))
+      # RSA-2048 signatures are 256 bytes
+      assert byte_size(sig_bytes) == 256
+    end
+  end
 end

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -1,0 +1,51 @@
+defmodule AuthifyTest.SAMLServiceProviderTest do
+  use AuthifyWeb.ConnCase, async: true
+
+  import Authify.AccountsFixtures
+
+  alias AuthifyTest.SAMLServiceProvider
+
+  describe "new/2" do
+    setup do: %{org: organization_fixture()}
+
+    test "generates an RSA private key (PEM)", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert is_binary(sp.private_key)
+      assert String.contains?(sp.private_key, "PRIVATE KEY")
+      assert [_] = :public_key.pem_decode(sp.private_key)
+    end
+
+    test "generates a self-signed X.509 certificate (PEM)", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert is_binary(sp.certificate)
+      assert String.contains?(sp.certificate, "BEGIN CERTIFICATE")
+      [pem_entry] = :public_key.pem_decode(sp.certificate)
+      cert = :public_key.pem_entry_decode(pem_entry)
+      assert match?({:Certificate, _, _, _}, cert)
+    end
+
+    test "registers a service provider record in the database", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert sp.sp_record.id
+      assert sp.sp_record.organization_id == org.id
+      assert sp.sp_record.is_active
+    end
+
+    test "each call produces a unique entity_id", %{org: org} do
+      sp1 = SAMLServiceProvider.new(org)
+      sp2 = SAMLServiceProvider.new(org)
+      refute sp1.entity_id == sp2.entity_id
+    end
+
+    test "accepts an explicit entity_id override via attrs", %{org: org} do
+      sp = SAMLServiceProvider.new(org, %{entity_id: "https://custom-sp.example.com"})
+      assert sp.entity_id == "https://custom-sp.example.com"
+      assert sp.sp_record.entity_id == "https://custom-sp.example.com"
+    end
+
+    test "stores the SP certificate PEM in the DB record", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert String.contains?(sp.sp_record.certificate, "BEGIN CERTIFICATE")
+    end
+  end
+end

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -127,4 +127,211 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
       assert {:error, :invalid_base64} = SAMLServiceProvider.extract_response(fake_conn)
     end
   end
+
+  describe "validate_response/4" do
+    setup do
+      org = organization_fixture()
+      sp = SAMLServiceProvider.new(org)
+      now = DateTime.utc_now()
+      expires = DateTime.add(now, 300, :second)
+      request_id = "_req_#{:crypto.strong_rand_bytes(4) |> Base.hex_encode32(case: :lower)}"
+
+      valid_xml = build_test_response_xml(sp, org, request_id, now, expires)
+
+      %{
+        org: org,
+        sp: sp,
+        request_id: request_id,
+        valid_xml: valid_xml,
+        now: now,
+        expires: expires
+      }
+    end
+
+    test "parses a valid assertion into the expected map shape", %{
+      sp: sp,
+      org: org,
+      valid_xml: valid_xml,
+      request_id: request_id
+    } do
+      conn = build_conn()
+
+      assert {:ok, assertion} =
+               SAMLServiceProvider.validate_response(sp, valid_xml, org,
+                 in_response_to: request_id,
+                 verify_signature: false,
+                 conn: conn
+               )
+
+      assert assertion.name_id == "test-subject-id"
+      assert assertion.session_index == "test-session-1"
+      assert assertion.in_response_to == request_id
+      assert is_map(assertion.attributes)
+    end
+
+    test "rejects an expired assertion", %{sp: sp, org: org, request_id: request_id, now: now} do
+      conn = build_conn()
+      past = DateTime.add(now, -600, :second)
+      expired_xml = build_test_response_xml(sp, org, request_id, now, past)
+
+      assert {:error, :assertion_expired} =
+               SAMLServiceProvider.validate_response(sp, expired_xml, org,
+                 in_response_to: request_id,
+                 verify_signature: false,
+                 conn: conn
+               )
+    end
+
+    test "rejects a response with wrong audience", %{
+      sp: sp,
+      org: org,
+      request_id: request_id,
+      now: now,
+      expires: expires
+    } do
+      conn = build_conn()
+
+      wrong_audience_xml =
+        build_test_response_xml(sp, org, request_id, now, expires,
+          audience: "https://wrong-sp.example.com"
+        )
+
+      assert {:error, :wrong_audience} =
+               SAMLServiceProvider.validate_response(sp, wrong_audience_xml, org,
+                 in_response_to: request_id,
+                 verify_signature: false,
+                 conn: conn
+               )
+    end
+
+    test "rejects a response with wrong Recipient", %{
+      sp: sp,
+      org: org,
+      request_id: request_id,
+      now: now,
+      expires: expires
+    } do
+      conn = build_conn()
+
+      wrong_recipient_xml =
+        build_test_response_xml(sp, org, request_id, now, expires,
+          recipient: "https://attacker.example.com/acs"
+        )
+
+      assert {:error, :wrong_recipient} =
+               SAMLServiceProvider.validate_response(sp, wrong_recipient_xml, org,
+                 in_response_to: request_id,
+                 verify_signature: false,
+                 conn: conn
+               )
+    end
+
+    test "rejects a response when InResponseTo does not match", %{
+      sp: sp,
+      org: org,
+      valid_xml: valid_xml
+    } do
+      conn = build_conn()
+
+      assert {:error, :in_response_to_mismatch} =
+               SAMLServiceProvider.validate_response(sp, valid_xml, org,
+                 in_response_to: "_completely_different_id",
+                 verify_signature: false,
+                 conn: conn
+               )
+    end
+
+    test "extracts attributes from AttributeStatement", %{
+      sp: sp,
+      org: org,
+      request_id: request_id,
+      now: now,
+      expires: expires
+    } do
+      conn = build_conn()
+
+      xml_with_attrs =
+        build_test_response_xml(sp, org, request_id, now, expires,
+          attributes: [{"email", "alice@example.com"}, {"firstName", "Alice"}]
+        )
+
+      assert {:ok, assertion} =
+               SAMLServiceProvider.validate_response(sp, xml_with_attrs, org,
+                 in_response_to: request_id,
+                 verify_signature: false,
+                 conn: conn
+               )
+
+      assert assertion.attributes["email"] == "alice@example.com"
+      assert assertion.attributes["firstName"] == "Alice"
+    end
+  end
+
+  # ── Private Test Helpers ──
+
+  defp build_test_response_xml(sp, org, request_id, now, expires, opts \\ []) do
+    audience = Keyword.get(opts, :audience, sp.entity_id)
+    recipient = Keyword.get(opts, :recipient, sp.acs_url)
+    attributes = Keyword.get(opts, :attributes, [])
+    issuer = "#{AuthifyWeb.Endpoint.url()}/#{org.slug}/saml/metadata"
+    not_before = DateTime.to_iso8601(DateTime.add(now, -5, :second))
+
+    attr_xml =
+      if attributes == [] do
+        ""
+      else
+        attr_elements =
+          Enum.map_join(attributes, "\n", fn {name, value} ->
+            """
+            <saml2:Attribute Name="#{name}">
+              <saml2:AttributeValue>#{value}</saml2:AttributeValue>
+            </saml2:Attribute>
+            """
+          end)
+
+        "<saml2:AttributeStatement>#{attr_elements}</saml2:AttributeStatement>"
+      end
+
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                   xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                   ID="_resp_test"
+                   InResponseTo="#{request_id}"
+                   IssueInstant="#{DateTime.to_iso8601(now)}"
+                   Destination="#{sp.acs_url}"
+                   Version="2.0">
+      <saml2:Issuer>#{issuer}</saml2:Issuer>
+      <saml2p:Status>
+        <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+      </saml2p:Status>
+      <saml2:Assertion ID="_assert_test"
+                   IssueInstant="#{DateTime.to_iso8601(now)}"
+                   Version="2.0">
+        <saml2:Issuer>#{issuer}</saml2:Issuer>
+        <saml2:Subject>
+          <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">test-subject-id</saml2:NameID>
+          <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+            <saml2:SubjectConfirmationData InResponseTo="#{request_id}"
+                                           NotOnOrAfter="#{DateTime.to_iso8601(expires)}"
+                                           Recipient="#{recipient}"/>
+          </saml2:SubjectConfirmation>
+        </saml2:Subject>
+        <saml2:Conditions NotBefore="#{not_before}"
+                       NotOnOrAfter="#{DateTime.to_iso8601(expires)}">
+          <saml2:AudienceRestriction>
+            <saml2:Audience>#{audience}</saml2:Audience>
+          </saml2:AudienceRestriction>
+        </saml2:Conditions>
+        <saml2:AuthnStatement SessionIndex="test-session-1">
+          <saml2:AuthnContext>
+            <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>
+          </saml2:AuthnContext>
+        </saml2:AuthnStatement>
+        #{attr_xml}
+      </saml2:Assertion>
+    </saml2p:Response>
+    """
+    |> String.trim()
+  end
 end

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -95,4 +95,36 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
       assert byte_size(sig_bytes) == 256
     end
   end
+
+  describe "extract_response/1" do
+    test "decodes SAMLResponse from an auto-submit HTML form" do
+      xml = "<saml2p:Response>test content</saml2p:Response>"
+      encoded = Base.encode64(xml)
+
+      html_body = """
+      <html>
+      <body onload="document.forms[0].submit()">
+        <form method="post" action="https://sp.example.com/saml/acs">
+          <input type="hidden" name="SAMLResponse" value="#{encoded}" />
+          <input type="submit" value="Continue" />
+        </form>
+      </body>
+      </html>
+      """
+
+      fake_conn = %Plug.Conn{resp_body: html_body}
+      assert {:ok, ^xml} = SAMLServiceProvider.extract_response(fake_conn)
+    end
+
+    test "returns error when no SAMLResponse field is present" do
+      fake_conn = %Plug.Conn{resp_body: "<html><body>no form</body></html>"}
+      assert {:error, :saml_response_not_found} = SAMLServiceProvider.extract_response(fake_conn)
+    end
+
+    test "returns error when SAMLResponse value is invalid base64" do
+      html_body = ~s(<form><input name="SAMLResponse" value="not!!valid!!base64" /></form>)
+      fake_conn = %Plug.Conn{resp_body: html_body}
+      assert {:error, :invalid_base64} = SAMLServiceProvider.extract_response(fake_conn)
+    end
+  end
 end

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -267,6 +267,63 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
     end
   end
 
+  describe "build_logout_request/2" do
+    setup do: %{org: organization_fixture()}
+
+    test "returns Base64-encoded XML and a request ID", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      assert {:ok, {encoded, request_id}} = SAMLServiceProvider.build_logout_request(sp, "sess-1")
+      assert is_binary(encoded)
+      assert String.starts_with?(request_id, "_")
+      xml = Base.decode64!(encoded)
+      assert String.contains?(xml, "LogoutRequest")
+    end
+
+    test "LogoutRequest XML contains the given SessionIndex", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      {:ok, {encoded, _}} = SAMLServiceProvider.build_logout_request(sp, "my-session-index")
+      xml = Base.decode64!(encoded)
+      assert String.contains?(xml, "my-session-index")
+    end
+
+    test "LogoutRequest is signed with ds:Signature", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+      {:ok, {encoded, _}} = SAMLServiceProvider.build_logout_request(sp, "sess-1")
+      xml = Base.decode64!(encoded)
+      assert String.contains?(xml, "<ds:Signature")
+    end
+  end
+
+  describe "validate_logout_response/2" do
+    setup do: %{org: organization_fixture()}
+
+    test "returns {:ok, :logged_out} for a Success status response", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+
+      logout_xml =
+        build_logout_response_xml(sp, org, "urn:oasis:names:tc:SAML:2.0:status:Success")
+
+      encoded = Base.encode64(logout_xml)
+      html = ~s(<form><input name="SAMLResponse" value="#{encoded}" /></form>)
+      fake_conn = %Plug.Conn{resp_body: html}
+      assert {:ok, :logged_out} = SAMLServiceProvider.validate_logout_response(sp, fake_conn)
+    end
+
+    test "returns {:error, {:unexpected_status, _}} for a non-Success status", %{org: org} do
+      sp = SAMLServiceProvider.new(org)
+
+      logout_xml =
+        build_logout_response_xml(sp, org, "urn:oasis:names:tc:SAML:2.0:status:Requester")
+
+      encoded = Base.encode64(logout_xml)
+      html = ~s(<form><input name="SAMLResponse" value="#{encoded}" /></form>)
+      fake_conn = %Plug.Conn{resp_body: html}
+
+      assert {:error, {:unexpected_status, "urn:oasis:names:tc:SAML:2.0:status:Requester"}} =
+               SAMLServiceProvider.validate_logout_response(sp, fake_conn)
+    end
+  end
+
   # ── Private Test Helpers ──
 
   defp build_test_response_xml(sp, org, request_id, now, expires, opts \\ []) do
@@ -331,6 +388,27 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
         #{attr_xml}
       </saml2:Assertion>
     </saml2p:Response>
+    """
+    |> String.trim()
+  end
+
+  defp build_logout_response_xml(sp, org, status_code) do
+    now = DateTime.to_iso8601(DateTime.utc_now())
+
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <saml2p:LogoutResponse xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                       xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                       ID="_logout_resp_test"
+                       InResponseTo="_logout_req_test"
+                       IssueInstant="#{now}"
+                       Destination="#{sp.sls_url}"
+                       Version="2.0">
+      <saml2:Issuer>#{AuthifyWeb.Endpoint.url()}/#{org.slug}/saml/metadata</saml2:Issuer>
+      <saml2p:Status>
+        <saml2p:StatusCode Value="#{status_code}"/>
+      </saml2p:Status>
+    </saml2p:LogoutResponse>
     """
     |> String.trim()
   end

--- a/test/protocol_clients/saml_sso_integration_test.exs
+++ b/test/protocol_clients/saml_sso_integration_test.exs
@@ -1,0 +1,150 @@
+defmodule AuthifyTest.SAMLSSOIntegrationTest do
+  @moduledoc false
+
+  use AuthifyWeb.ConnCase, async: true
+
+  import Authify.AccountsFixtures
+  import Authify.SAMLFixtures
+
+  alias AuthifyTest.SAMLServiceProvider
+
+  describe "SP-initiated SSO with signed AuthnRequest and signed assertion" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org, %{"email" => "sso.user@example.com"})
+
+      # Create an IdP signing cert so Authify will sign the assertion in responses
+      certificate_fixture(%{organization: org})
+
+      sp = SAMLServiceProvider.new(org)
+
+      %{org: org, user: user, sp: sp}
+    end
+
+    test "complete SP-initiated SSO flow: signed request → signed assertion → validated", %{
+      org: org,
+      user: user,
+      sp: sp
+    } do
+      # ── Step 1: SP generates a signed AuthnRequest ─────────────────────
+      {:ok, {encoded_request, request_id}} = SAMLServiceProvider.build_authn_request(sp)
+
+      # Verify the request is actually signed
+      assert String.contains?(Base.decode64!(encoded_request), "<ds:Signature")
+
+      # ── Step 2: Post signed AuthnRequest to Authify's SSO endpoint ─────
+      conn = build_conn() |> log_in_user(user)
+
+      sso_resp =
+        get(conn, "/#{org.slug}/saml/sso", %{
+          "SAMLRequest" => encoded_request,
+          "RelayState" => "integration-test"
+        })
+
+      assert sso_resp.status == 302
+      continue_path = redirected_to(sso_resp)
+      assert String.contains?(continue_path, "/#{org.slug}/saml/continue/")
+
+      session_id = String.split(continue_path, "/") |> List.last()
+
+      # ── Step 3: Follow the continue redirect as the authenticated user ─
+      continue_conn = build_conn() |> log_in_user(user)
+      assertion_resp = get(continue_conn, continue_path)
+
+      assert assertion_resp.status == 200
+      body = assertion_resp.resp_body
+      assert String.contains?(body, sp.acs_url)
+      assert String.contains?(body, "SAMLResponse")
+
+      # ── Step 4: SP extracts the SAMLResponse from the auto-submit form ─
+      {:ok, response_xml} = SAMLServiceProvider.extract_response(assertion_resp)
+
+      assert String.contains?(response_xml, "Response") or
+               String.contains?(response_xml, "response")
+
+      # ── Step 5: SP validates the response ────────────────────────────────
+      assert {:ok, assertion} =
+               SAMLServiceProvider.validate_response(sp, response_xml, org,
+                 in_response_to: request_id
+               )
+
+      # ── Step 6: Verify assertion contents ────────────────────────────────
+      assert assertion.in_response_to == request_id
+      assert assertion.session_index == session_id
+      assert is_map(assertion.attributes)
+
+      # ── Step 7: Verify SAML session was persisted correctly ──────────────
+      saml_session = Authify.SAML.get_session(session_id)
+      assert saml_session.user_id == user.id
+      assert saml_session.service_provider_id == sp.sp_record.id
+    end
+
+    test "Authify rejects a signed AuthnRequest from an unregistered SP", %{
+      org: org,
+      user: user,
+      sp: sp
+    } do
+      {:ok, {encoded_request, _}} = SAMLServiceProvider.build_authn_request(sp)
+      xml = Base.decode64!(encoded_request)
+
+      # Replace SP's entity_id with one that is not registered
+      tampered_xml = String.replace(xml, sp.entity_id, "https://unknown-sp.example.com")
+      tampered_encoded = Base.encode64(tampered_xml)
+
+      conn = build_conn() |> log_in_user(user)
+      resp = get(conn, "/#{org.slug}/saml/sso", %{"SAMLRequest" => tampered_encoded})
+
+      assert resp.status == 400
+      assert String.contains?(resp.resp_body, "Unknown service provider")
+    end
+  end
+
+  describe "SP-initiated SLO flow" do
+    setup do
+      org = organization_fixture()
+      user = user_for_organization_fixture(org)
+      certificate_fixture(%{organization: org})
+      sp = SAMLServiceProvider.new(org)
+      %{org: org, user: user, sp: sp}
+    end
+
+    test "SP-initiated LogoutRequest is processed and SP validates the LogoutResponse", %{
+      org: org,
+      user: user,
+      sp: sp
+    } do
+      # Establish a SAML session via SSO first
+      {:ok, {encoded_request, _}} = SAMLServiceProvider.build_authn_request(sp)
+
+      sso_conn = build_conn() |> log_in_user(user)
+
+      sso_resp =
+        get(sso_conn, "/#{org.slug}/saml/sso", %{"SAMLRequest" => encoded_request})
+
+      continue_path = redirected_to(sso_resp)
+      session_id = String.split(continue_path, "/") |> List.last()
+
+      continue_conn = build_conn() |> log_in_user(user)
+      get(continue_conn, continue_path)
+
+      # SP initiates logout using the session_id as session_index
+      {:ok, {encoded_logout_req, _}} = SAMLServiceProvider.build_logout_request(sp, session_id)
+
+      logout_conn = build_conn() |> log_in_user(user)
+
+      slo_resp =
+        get(logout_conn, "/#{org.slug}/saml/slo", %{
+          "SAMLRequest" => encoded_logout_req,
+          "RelayState" => "logout-relay"
+        })
+
+      # Authify should return a LogoutResponse form pointing to the SP's sls_url
+      assert slo_resp.status == 200
+      assert String.contains?(slo_resp.resp_body, "SAMLResponse")
+      assert String.contains?(slo_resp.resp_body, sp.sls_url)
+
+      # SP validates the logout response
+      assert {:ok, :logged_out} = SAMLServiceProvider.validate_logout_response(sp, slo_resp)
+    end
+  end
+end

--- a/test/protocol_clients/saml_sso_integration_test.exs
+++ b/test/protocol_clients/saml_sso_integration_test.exs
@@ -59,8 +59,7 @@ defmodule AuthifyTest.SAMLSSOIntegrationTest do
       # ── Step 4: SP extracts the SAMLResponse from the auto-submit form ─
       {:ok, response_xml} = SAMLServiceProvider.extract_response(assertion_resp)
 
-      assert String.contains?(response_xml, "Response") or
-               String.contains?(response_xml, "response")
+      assert String.contains?(response_xml, "<saml2p:Response")
 
       # ── Step 5: SP validates the response ────────────────────────────────
       assert {:ok, assertion} =

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -1,0 +1,50 @@
+defmodule AuthifyTest.SAMLServiceProvider do
+  @moduledoc false
+
+  defstruct [:private_key, :certificate, :entity_id, :acs_url, :sls_url, :org, :sp_record]
+
+  def new(org, attrs \\ %{}) do
+    private_key = X509.PrivateKey.new_rsa(2048)
+
+    certificate =
+      X509.Certificate.self_signed(
+        private_key,
+        "/C=US/O=Test SP/CN=Test SAML SP",
+        template: :server
+      )
+
+    key_pem = X509.PrivateKey.to_pem(private_key)
+    cert_pem = X509.Certificate.to_pem(certificate)
+
+    uid = :crypto.strong_rand_bytes(8) |> Base.hex_encode32(case: :lower)
+    entity_id = Map.get(attrs, :entity_id, "https://sp-#{uid}.example.com")
+    acs_url = Map.get(attrs, :acs_url, "#{entity_id}/saml/acs")
+    sls_url = Map.get(attrs, :sls_url, "#{entity_id}/saml/sls")
+
+    {:ok, sp_record} =
+      Authify.SAML.create_service_provider(%{
+        name: Map.get(attrs, :name, "Test SP #{uid}"),
+        entity_id: entity_id,
+        acs_url: acs_url,
+        sls_url: sls_url,
+        certificate: cert_pem,
+        metadata: nil,
+        attribute_mapping: Jason.encode!(%{}),
+        sign_requests: true,
+        sign_assertions: true,
+        encrypt_assertions: false,
+        is_active: true,
+        organization_id: org.id
+      })
+
+    %__MODULE__{
+      private_key: key_pem,
+      certificate: cert_pem,
+      entity_id: entity_id,
+      acs_url: acs_url,
+      sls_url: sls_url,
+      org: org,
+      sp_record: sp_record
+    }
+  end
+end

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -1,5 +1,7 @@
 defmodule AuthifyTest.SAMLServiceProvider do
   @moduledoc false
+  @endpoint AuthifyWeb.Endpoint
+  import Phoenix.ConnTest
   import SweetXml
 
   defstruct [:private_key, :certificate, :entity_id, :acs_url, :sls_url, :org, :sp_record]
@@ -143,8 +145,8 @@ defmodule AuthifyTest.SAMLServiceProvider do
 
     cert_b64 =
       sp.certificate
-      |> String.replace("-----BEGIN CERTIFICATE-----", "")
-      |> String.replace("-----END CERTIFICATE-----", "")
+      |> String.replace("-----BEGIN CERTIFICATE----", "")
+      |> String.replace("-----END CERTIFICATE----", "")
       |> String.replace(~r/\s/, "")
 
     signature_element =
@@ -155,7 +157,7 @@ defmodule AuthifyTest.SAMLServiceProvider do
         <ds:KeyInfo>
           <ds:X509Data>
             <ds:X509Certificate>#{cert_b64}</ds:X509Certificate>
-          </ds:KeyInfo>
+          </ds:X509Data>
         </ds:KeyInfo>
       </ds:Signature>
       """
@@ -179,9 +181,8 @@ defmodule AuthifyTest.SAMLServiceProvider do
     in_response_to = Keyword.get(opts, :in_response_to)
     verify_sig = Keyword.get(opts, :verify_signature, true)
     clock_skew = Keyword.get(opts, :clock_skew, 60)
-    conn = Keyword.get(opts, :conn)
 
-    with :ok <- maybe_verify_signature(response_xml, org, verify_sig, conn),
+    with :ok <- maybe_verify_signature(response_xml, org, verify_sig),
          {:ok, assertion} <- parse_assertion(response_xml),
          :ok <- validate_not_before(assertion.not_before, clock_skew),
          :ok <- validate_not_on_or_after(assertion.not_on_or_after, clock_skew),
@@ -207,11 +208,11 @@ defmodule AuthifyTest.SAMLServiceProvider do
     end
   end
 
-  defp maybe_verify_signature(_xml, _org, false, _conn), do: :ok
+  defp maybe_verify_signature(_xml, _org, false), do: :ok
 
-  defp maybe_verify_signature(xml, org, true, conn) do
+  defp maybe_verify_signature(xml, org, true) do
     if String.contains?(xml, "<ds:Signature") do
-      with {:ok, cert_pem} <- fetch_idp_cert(org, conn) do
+      with {:ok, cert_pem} <- fetch_idp_cert(org) do
         fake_cert = %Authify.Accounts.Certificate{
           certificate: cert_pem,
           private_key: ""
@@ -228,34 +229,27 @@ defmodule AuthifyTest.SAMLServiceProvider do
     end
   end
 
-  defp fetch_idp_cert(org, _conn) do
-    base_url = AuthifyWeb.Endpoint.url()
-    url = "#{base_url}/#{org.slug}/saml/metadata"
+  defp fetch_idp_cert(org) do
+    conn = build_conn()
+    resp = get(conn, "/#{org.slug}/saml/metadata")
 
-    case :httpc.request(:get, {url, []}, [], body_format: :binary) do
-      {:ok, {{_, 200, _}, _headers, body}} ->
-        case Regex.run(
-               ~r/<[^:]*:X509Certificate[^>]*>([\s\S]*?)<\/[^:]*:X509Certificate>/,
-               body
-             ) do
-          [_, cert_b64] ->
-            trimmed = String.trim(cert_b64)
+    body = resp.resp_body
 
-            if trimmed == "" or String.starts_with?(trimmed, "NO_SAML") do
-              {:error, :no_idp_signing_cert}
-            else
-              {:ok, "-----BEGIN CERTIFICATE-----\n#{trimmed}\n-----END CERTIFICATE-----"}
-            end
+    case Regex.run(
+           ~r/<[^:]*:X509Certificate[^>]*>([\s\S]*?)<\/[^:]*:X509Certificate>/,
+           body
+         ) do
+      [_, cert_b64] ->
+        trimmed = String.trim(cert_b64)
 
-          nil ->
-            {:error, :no_idp_signing_cert}
+        if trimmed == "" or String.starts_with?(trimmed, "NO_SAML") do
+          {:error, :no_idp_signing_cert}
+        else
+          {:ok, "-----BEGIN CERTIFICATE----\n#{trimmed}\n-----END CERTIFICATE----"}
         end
 
-      {:ok, {{_, status, _}, _, _}} ->
-        {:error, {:http_error, status}}
-
-      {:error, reason} ->
-        {:error, {:http_error, reason}}
+      nil ->
+        {:error, :no_idp_signing_cert}
     end
   end
 

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -56,6 +56,19 @@ defmodule AuthifyTest.SAMLServiceProvider do
     {:ok, {Base.encode64(signed_xml), request_id}}
   end
 
+  def extract_response(%{resp_body: body}) do
+    case Regex.run(~r/name="SAMLResponse" value="([^"]+)"/, body) do
+      [_, b64] ->
+        case Base.decode64(b64) do
+          {:ok, xml} -> {:ok, xml}
+          :error -> {:error, :invalid_base64}
+        end
+
+      nil ->
+        {:error, :saml_response_not_found}
+    end
+  end
+
   # ── Private Helpers ──
 
   defp build_authn_request_xml(sp, request_id, now) do

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -73,6 +73,7 @@ defmodule AuthifyTest.SAMLServiceProvider do
                             Version="2.0"
                             Destination="#{AuthifyWeb.Endpoint.url()}/#{sp.org.slug}/saml/slo">
         <saml2:Issuer>#{sp.entity_id}</saml2:Issuer>
+        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:unspecified">sp-logout-subject</saml2:NameID>
         <saml2p:SessionIndex>#{session_index}</saml2p:SessionIndex>
       </saml2p:LogoutRequest>
       """
@@ -145,8 +146,8 @@ defmodule AuthifyTest.SAMLServiceProvider do
 
     cert_b64 =
       sp.certificate
-      |> String.replace("-----BEGIN CERTIFICATE----", "")
-      |> String.replace("-----END CERTIFICATE----", "")
+      |> String.replace("-----BEGIN CERTIFICATE-----", "")
+      |> String.replace("-----END CERTIFICATE-----", "")
       |> String.replace(~r/\s/, "")
 
     signature_element =
@@ -193,8 +194,6 @@ defmodule AuthifyTest.SAMLServiceProvider do
     end
   end
 
-  # ── Private Helpers ──
-
   def validate_logout_response(%__MODULE__{} = _sp, conn) do
     with {:ok, response_xml} <- extract_response(conn) do
       status =
@@ -207,6 +206,8 @@ defmodule AuthifyTest.SAMLServiceProvider do
       end
     end
   end
+
+  # ── Private Helpers ──
 
   defp maybe_verify_signature(_xml, _org, false), do: :ok
 
@@ -245,7 +246,7 @@ defmodule AuthifyTest.SAMLServiceProvider do
         if trimmed == "" or String.starts_with?(trimmed, "NO_SAML") do
           {:error, :no_idp_signing_cert}
         else
-          {:ok, "-----BEGIN CERTIFICATE----\n#{trimmed}\n-----END CERTIFICATE----"}
+          {:ok, "-----BEGIN CERTIFICATE-----\n#{trimmed}\n-----END CERTIFICATE-----"}
         end
 
       nil ->

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -57,6 +57,29 @@ defmodule AuthifyTest.SAMLServiceProvider do
     {:ok, {Base.encode64(signed_xml), request_id}}
   end
 
+  def build_logout_request(%__MODULE__{} = sp, session_index) do
+    request_id = generate_id()
+    now = DateTime.utc_now()
+
+    unsigned_xml =
+      """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <saml2p:LogoutRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                            xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                            ID="#{request_id}"
+                            IssueInstant="#{DateTime.to_iso8601(now)}"
+                            Version="2.0"
+                            Destination="#{AuthifyWeb.Endpoint.url()}/#{sp.org.slug}/saml/slo">
+        <saml2:Issuer>#{sp.entity_id}</saml2:Issuer>
+        <saml2p:SessionIndex>#{session_index}</saml2p:SessionIndex>
+      </saml2p:LogoutRequest>
+      """
+      |> String.trim()
+
+    signed_xml = sign_xml(unsigned_xml, sp)
+    {:ok, {Base.encode64(signed_xml), request_id}}
+  end
+
   def extract_response(%{resp_body: body}) do
     case Regex.run(~r/name="SAMLResponse" value="([^"]+)"/, body) do
       [_, b64] ->
@@ -170,6 +193,19 @@ defmodule AuthifyTest.SAMLServiceProvider do
   end
 
   # ── Private Helpers ──
+
+  def validate_logout_response(%__MODULE__{} = _sp, conn) do
+    with {:ok, response_xml} <- extract_response(conn) do
+      status =
+        response_xml
+        |> xpath(~x"//saml2p:StatusCode/@Value"s)
+
+      case status do
+        "urn:oasis:names:tc:SAML:2.0:status:Success" -> {:ok, :logged_out}
+        other -> {:error, {:unexpected_status, other}}
+      end
+    end
+  end
 
   defp maybe_verify_signature(_xml, _org, false, _conn), do: :ok
 

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -47,4 +47,92 @@ defmodule AuthifyTest.SAMLServiceProvider do
       sp_record: sp_record
     }
   end
+
+  def build_authn_request(%__MODULE__{} = sp) do
+    request_id = generate_id()
+    now = DateTime.utc_now()
+    unsigned_xml = build_authn_request_xml(sp, request_id, now)
+    signed_xml = sign_xml(unsigned_xml, sp)
+    {:ok, {Base.encode64(signed_xml), request_id}}
+  end
+
+  # ── Private Helpers ──
+
+  defp build_authn_request_xml(sp, request_id, now) do
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <saml2p:AuthnRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol"
+                       xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion"
+                       ID="#{request_id}"
+                       IssueInstant="#{DateTime.to_iso8601(now)}"
+                       Version="2.0"
+                       AssertionConsumerServiceURL="#{sp.acs_url}"
+                       Destination="#{AuthifyWeb.Endpoint.url()}/#{sp.org.slug}/saml/sso">
+      <saml2:Issuer>#{sp.entity_id}</saml2:Issuer>
+      <saml2p:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"/>
+    </saml2p:AuthnRequest>
+    """
+    |> String.trim()
+  end
+
+  defp sign_xml(xml_string, %__MODULE__{} = sp) do
+    canonical_xml = Authify.SAML.XMLSignature.canonicalize_xml(xml_string)
+    digest = :crypto.hash(:sha256, canonical_xml)
+    digest_b64 = Base.encode64(digest)
+
+    signed_info =
+      """
+      <ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+        <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+        <ds:Reference URI="">
+          <ds:Transforms>
+            <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+            <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+          </ds:Transforms>
+          <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+          <ds:DigestValue>#{digest_b64}</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      """
+      |> String.trim()
+
+    canonical_signed_info = Authify.SAML.XMLSignature.canonicalize_xml(signed_info)
+
+    [pem_entry] = :public_key.pem_decode(sp.private_key)
+    private_key = :public_key.pem_entry_decode(pem_entry)
+    sig_bytes = :public_key.sign(canonical_signed_info, :sha256, private_key)
+    sig_b64 = Base.encode64(sig_bytes)
+
+    cert_b64 =
+      sp.certificate
+      |> String.replace("-----BEGIN CERTIFICATE-----", "")
+      |> String.replace("-----END CERTIFICATE-----", "")
+      |> String.replace(~r/\s/, "")
+
+    signature_element =
+      """
+      <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        #{signed_info}
+        <ds:SignatureValue>#{sig_b64}</ds:SignatureValue>
+        <ds:KeyInfo>
+          <ds:X509Data>
+            <ds:X509Certificate>#{cert_b64}</ds:X509Certificate>
+          </ds:KeyInfo>
+        </ds:KeyInfo>
+      </ds:Signature>
+      """
+      |> String.trim()
+
+    # Insert signature after the first Issuer element (SAML convention)
+    String.replace(
+      xml_string,
+      ~r/(<saml2:Issuer[^>]*>.*?<\/saml2:Issuer>)/s,
+      "\\1\n  #{signature_element}"
+    )
+  end
+
+  defp generate_id do
+    "_" <> (:crypto.strong_rand_bytes(20) |> Base.hex_encode32(case: :lower))
+  end
 end

--- a/test/support/protocol_clients/saml_service_provider.ex
+++ b/test/support/protocol_clients/saml_service_provider.ex
@@ -1,5 +1,6 @@
 defmodule AuthifyTest.SAMLServiceProvider do
   @moduledoc false
+  import SweetXml
 
   defstruct [:private_key, :certificate, :entity_id, :acs_url, :sls_url, :org, :sp_record]
 
@@ -147,5 +148,150 @@ defmodule AuthifyTest.SAMLServiceProvider do
 
   defp generate_id do
     "_" <> (:crypto.strong_rand_bytes(20) |> Base.hex_encode32(case: :lower))
+  end
+
+  # ── Assertion Validation ──
+
+  def validate_response(%__MODULE__{} = sp, response_xml, org, opts \\ []) do
+    in_response_to = Keyword.get(opts, :in_response_to)
+    verify_sig = Keyword.get(opts, :verify_signature, true)
+    clock_skew = Keyword.get(opts, :clock_skew, 60)
+    conn = Keyword.get(opts, :conn)
+
+    with :ok <- maybe_verify_signature(response_xml, org, verify_sig, conn),
+         {:ok, assertion} <- parse_assertion(response_xml),
+         :ok <- validate_not_before(assertion.not_before, clock_skew),
+         :ok <- validate_not_on_or_after(assertion.not_on_or_after, clock_skew),
+         :ok <- validate_audience(assertion.audience, sp.entity_id),
+         :ok <- validate_recipient(assertion.recipient, sp.acs_url),
+         :ok <- validate_in_response_to(assertion.in_response_to, in_response_to) do
+      {:ok, assertion}
+    end
+  end
+
+  # ── Private Helpers ──
+
+  defp maybe_verify_signature(_xml, _org, false, _conn), do: :ok
+
+  defp maybe_verify_signature(xml, org, true, conn) do
+    if String.contains?(xml, "<ds:Signature") do
+      with {:ok, cert_pem} <- fetch_idp_cert(org, conn) do
+        fake_cert = %Authify.Accounts.Certificate{
+          certificate: cert_pem,
+          private_key: ""
+        }
+
+        case Authify.SAML.XMLSignature.verify_signature(xml, fake_cert) do
+          {:ok, true} -> :ok
+          {:ok, false} -> {:error, :signature_invalid}
+          {:error, reason} -> {:error, {:signature_error, reason}}
+        end
+      end
+    else
+      :ok
+    end
+  end
+
+  defp fetch_idp_cert(org, _conn) do
+    base_url = AuthifyWeb.Endpoint.url()
+    url = "#{base_url}/#{org.slug}/saml/metadata"
+
+    case :httpc.request(:get, {url, []}, [], body_format: :binary) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        case Regex.run(
+               ~r/<[^:]*:X509Certificate[^>]*>([\s\S]*?)<\/[^:]*:X509Certificate>/,
+               body
+             ) do
+          [_, cert_b64] ->
+            trimmed = String.trim(cert_b64)
+
+            if trimmed == "" or String.starts_with?(trimmed, "NO_SAML") do
+              {:error, :no_idp_signing_cert}
+            else
+              {:ok, "-----BEGIN CERTIFICATE-----\n#{trimmed}\n-----END CERTIFICATE-----"}
+            end
+
+          nil ->
+            {:error, :no_idp_signing_cert}
+        end
+
+      {:ok, {{_, status, _}, _, _}} ->
+        {:error, {:http_error, status}}
+
+      {:error, reason} ->
+        {:error, {:http_error, reason}}
+    end
+  end
+
+  defp parse_assertion(response_xml) do
+    result =
+      xmap(response_xml,
+        in_response_to: ~x"//saml2p:Response/@InResponseTo"s,
+        name_id: ~x"//saml2:NameID/text()"s,
+        not_before: ~x"//saml2:Conditions/@NotBefore"s,
+        not_on_or_after: ~x"//saml2:Conditions/@NotOnOrAfter"s,
+        audience: ~x"//saml2:Audience/text()"s,
+        recipient: ~x"//saml2:SubjectConfirmationData/@Recipient"s,
+        subject_not_on_or_after: ~x"//saml2:SubjectConfirmationData/@NotOnOrAfter"s,
+        session_index: ~x"//saml2:AuthnStatement/@SessionIndex"s
+      )
+
+    attributes = extract_attribute_map(response_xml)
+    {:ok, Map.put(result, :attributes, attributes)}
+  rescue
+    _ -> {:error, :assertion_parse_failed}
+  end
+
+  defp extract_attribute_map(response_xml) do
+    response_xml
+    |> xpath(~x"//saml2:Attribute"l,
+      name: ~x"./@Name"s,
+      value: ~x"./saml2:AttributeValue/text()"s
+    )
+    |> Enum.into(%{}, fn %{name: name, value: value} -> {name, value} end)
+  rescue
+    _ -> %{}
+  end
+
+  defp validate_not_before(not_before_str, clock_skew) do
+    case DateTime.from_iso8601(not_before_str) do
+      {:ok, not_before, _} ->
+        adjusted_now = DateTime.add(DateTime.utc_now(), clock_skew, :second)
+
+        if DateTime.compare(not_before, adjusted_now) in [:lt, :eq],
+          do: :ok,
+          else: {:error, :assertion_not_yet_valid}
+
+      _ ->
+        {:error, :invalid_not_before}
+    end
+  end
+
+  defp validate_not_on_or_after(not_on_or_after_str, clock_skew) do
+    case DateTime.from_iso8601(not_on_or_after_str) do
+      {:ok, not_on_or_after, _} ->
+        adjusted_now = DateTime.add(DateTime.utc_now(), -clock_skew, :second)
+
+        if DateTime.compare(adjusted_now, not_on_or_after) in [:lt, :eq],
+          do: :ok,
+          else: {:error, :assertion_expired}
+
+      _ ->
+        {:error, :invalid_not_on_or_after}
+    end
+  end
+
+  defp validate_audience(audience, expected_entity_id) do
+    if audience == expected_entity_id, do: :ok, else: {:error, :wrong_audience}
+  end
+
+  defp validate_recipient(recipient, expected_acs_url) do
+    if recipient == expected_acs_url, do: :ok, else: {:error, :wrong_recipient}
+  end
+
+  defp validate_in_response_to(_actual, nil), do: :ok
+
+  defp validate_in_response_to(actual, expected) do
+    if actual == expected, do: :ok, else: {:error, :in_response_to_mismatch}
   end
 end


### PR DESCRIPTION
## Summary

- Adds `AuthifyTest.SAMLServiceProvider` — an in-process SAML 2.0 SP simulator that generates signed AuthnRequests/LogoutRequests and validates signed SAMLResponses, giving integration tests full protocol fidelity on both sides of the SAML exchange
- Enables assertion signing in `SAMLController` (`sign: true`) so Authify signs responses when a SAML signing certificate is available — backward-safe, falls back to unsigned when no cert exists
- Adds unit tests for the SP simulator and two end-to-end integration tests covering SP-initiated SSO and SP-initiated SLO flows

## What's in the SP simulator

| Function | Purpose |
|---|---|
| `new/2` | Generates RSA-2048 key + self-signed cert, registers SP in DB |
| `build_authn_request/1` | Produces Base64-encoded XMLDSig-signed AuthnRequest |
| `build_logout_request/2` | Produces Base64-encoded XMLDSig-signed LogoutRequest |
| `extract_response/1` | Extracts and Base64-decodes `SAMLResponse` from HTTP-POST form |
| `validate_response/4` | Verifies signature, time bounds, audience, recipient, InResponseTo, and extracts attributes |
| `validate_logout_response/2` | Checks status code of LogoutResponse |

## Test plan

- [x] All 1885 existing tests continue to pass
- [x] `mix test test/protocol_clients/` — 27 tests, 0 failures
- [x] Pre-commit hooks (credo + sobelow) pass clean
- [x] Integration test covers: signed AuthnRequest → signed assertion → full SP-side validation, and SLO round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)