### PR TITLE
test(scim): SCIMConsumer protocol client + OAuth2 SCIM scope fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ npm-debug.log
 config/dev.exs
 
 TODO.md
+
+# superpowers-generated plans and specs
+/docs

--- a/lib/authify/o_auth/application.ex
+++ b/lib/authify/o_auth/application.ex
@@ -223,8 +223,11 @@ defmodule Authify.OAuth.Application do
       # Validate scopes based on application type
       valid_scopes =
         case scope_type do
-          :oauth -> Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
-          :management_api -> Authify.Scopes.management_api_scopes()
+          :oauth ->
+            Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
+
+          :management_api ->
+            Authify.Scopes.management_api_scopes() ++ Authify.Scopes.scim_scopes()
         end
 
       invalid_scopes = Enum.reject(scopes, &(&1 in valid_scopes))
@@ -251,9 +254,14 @@ defmodule Authify.OAuth.Application do
       # Validate scopes based on application type
       valid_scopes =
         case application.application_type do
-          "oauth2_app" -> Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
-          "management_api_app" -> Authify.Scopes.management_api_scopes()
-          _ -> Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
+          "oauth2_app" ->
+            Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
+
+          "management_api_app" ->
+            Authify.Scopes.management_api_scopes() ++ Authify.Scopes.scim_scopes()
+
+          _ ->
+            Authify.Scopes.oauth_scopes() ++ Authify.Scopes.management_api_scopes()
         end
 
       invalid_scopes = Enum.reject(scopes, &(&1 in valid_scopes))

--- a/test/protocol_clients/scim_consumer_integration_test.exs
+++ b/test/protocol_clients/scim_consumer_integration_test.exs
@@ -1,0 +1,132 @@
+defmodule AuthifyTest.SCIMConsumerIntegrationTest do
+  @moduledoc """
+  End-to-end integration test for AuthifyTest.SCIMConsumer.
+
+  Exercises the complete SCIM user and group provisioning lifecycle against
+  Authify's real SCIM endpoints using a real OAuth bearer token. Catches:
+
+  - Request body schema compliance (schemas URIs, PATCH envelope)
+  - Response schema validation (required fields per RFC 7643)
+  - ETag round-trip (cached ETag sent as If-Match on updates)
+  - Soft delete behavior (user remains fetchable after delete)
+  - Group member management via PATCH
+  - OAuth scope enforcement (real token with scim:read/scim:write)
+  """
+
+  use AuthifyWeb.ConnCase, async: true
+
+  import Authify.AccountsFixtures
+  import Authify.OAuthFixtures
+
+  alias AuthifyTest.OAuthClient
+  alias AuthifyTest.SCIMConsumer
+
+  @tag :capture_log
+  test "complete user and group provisioning lifecycle with real OAuth token" do
+    # ── Setup: obtain real bearer token via OAuth client credentials ──
+
+    org = organization_fixture()
+
+    app =
+      management_api_application_fixture(
+        organization: org,
+        scopes: Enum.join(["scim:read", "scim:write"], " ")
+      )
+
+    oauth_client = OAuthClient.new(build_conn(), app, org)
+
+    {:ok, tokens} =
+      OAuthClient.client_credentials(oauth_client, scopes: ["scim:read", "scim:write"])
+
+    consumer = SCIMConsumer.new(build_conn(), org, token: tokens.access_token)
+
+    # ── Step 1: Create user ────────────────────────────────────────
+
+    user_name = "e2e-#{System.monotonic_time()}"
+
+    assert {:ok, user} =
+             SCIMConsumer.create_user(consumer, %{
+               userName: user_name,
+               name: %{givenName: "E2E", familyName: "User"},
+               emails: [%{value: "e2e@example.com", primary: true}]
+             })
+
+    # Assert SCIM response schema
+    assert user["schemas"] == ["urn:ietf:params:scim:schemas:core:2.0:User"]
+    assert is_binary(user["id"])
+    assert user["meta"]["resourceType"] == "User"
+    assert is_binary(user["meta"]["location"])
+    assert user["userName"] == user_name
+
+    # ── Step 2: Fetch user by ID ───────────────────────────────────
+
+    assert {:ok, fetched} = SCIMConsumer.fetch_user(consumer, user["id"])
+    assert fetched["id"] == user["id"]
+    assert fetched["userName"] == user_name
+
+    # ── Step 3: Update user via PUT (deactivate) ───────────────────
+
+    assert {:ok, deactivated} =
+             SCIMConsumer.update_user(consumer, user["id"], %{active: false})
+
+    assert deactivated["active"] == false
+
+    # ── Step 4: Patch user via PATCH (re-activate) ─────────────────
+
+    assert {:ok, reactivated} =
+             SCIMConsumer.patch_user(consumer, user["id"], [
+               %{"op" => "replace", "path" => "active", "value" => true}
+             ])
+
+    assert reactivated["active"] == true
+
+    # ── Step 5: Delete user (soft delete → 204) ────────────────────
+
+    assert :ok = SCIMConsumer.delete_user(consumer, user["id"])
+
+    # ── Step 6: Fetch user after delete (soft delete, not 404) ─────
+
+    assert {:ok, deleted_user} = SCIMConsumer.fetch_user(consumer, user["id"])
+    assert deleted_user["active"] == false
+
+    # ── Step 7: Create group with initial member ───────────────────
+
+    group_name = "grp-e2e-#{System.monotonic_time()}"
+
+    assert {:ok, group} = SCIMConsumer.create_group(consumer, group_name)
+    assert group["schemas"] == ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+    assert is_binary(group["id"])
+    assert group["displayName"] == group_name
+
+    # ── Step 8: Update group members (add, then remove) ────────────
+
+    # Create another user to add to the group
+    member_name = "e2e-member-#{System.monotonic_time()}"
+
+    {:ok, member_user} =
+      SCIMConsumer.create_user(consumer, %{
+        userName: member_name,
+        name: %{givenName: "E2E", familyName: "Member"},
+        emails: [%{value: "member@example.com"}]
+      })
+
+    assert {:ok, added} =
+             SCIMConsumer.update_group_members(consumer, group["id"],
+               add: [member_user["id"]],
+               remove: []
+             )
+
+    members = added["members"] || []
+    assert match?([_], members)
+    assert Enum.at(members, 0)["value"] == member_user["id"]
+
+    assert {:ok, removed} =
+             SCIMConsumer.update_group_members(consumer, group["id"],
+               add: [],
+               remove: [member_user["id"]]
+             )
+
+    members_after = removed["members"] || []
+    assert members_after == []
+  end
+end

--- a/test/protocol_clients/scim_consumer_test.exs
+++ b/test/protocol_clients/scim_consumer_test.exs
@@ -1,0 +1,399 @@
+defmodule AuthifyTest.SCIMConsumerTest do
+  @moduledoc false
+
+  use AuthifyWeb.ConnCase, async: true
+
+  import Authify.AccountsFixtures
+
+  alias AuthifyTest.OAuthClient
+  alias AuthifyTest.SCIMConsumer
+
+  # All tests get a valid token via PAT. Unit tests focus on consumer behavior;
+  # the integration test exercises the full OAuth2 client_credentials scope flow.
+  setup do
+    org = organization_fixture()
+    admin = user_fixture(organization: org, role: "admin")
+
+    {:ok, token_string} =
+      OAuthClient.create_pat(admin, org, scopes: Authify.Scopes.pat_scopes())
+
+    consumer = SCIMConsumer.new(build_conn(), org, token: token_string)
+
+    {:ok,
+     %{
+       org: org,
+       admin: admin,
+       consumer: consumer,
+       token: token_string
+     }}
+  end
+
+  defp authenticated_consumer(org) do
+    admin = user_fixture(organization: org, role: "admin")
+    {:ok, token} = OAuthClient.create_pat(admin, org, scopes: Authify.Scopes.pat_scopes())
+    SCIMConsumer.new(build_conn(), org, token: token)
+  end
+
+  # ── Struct ───────────────────────────────────────
+
+  describe "new/3" do
+    test "creates a consumer struct with conn, org, and token" do
+      org = organization_fixture()
+      consumer = SCIMConsumer.new(build_conn(), org, token: "fake-token")
+
+      assert consumer.org == org
+      assert consumer.token == "fake-token"
+    end
+  end
+
+  # ── Request Construction ─────────────────────────
+
+  describe "create_user/2" do
+    test "POST /Users sends correct User schemas URI" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      assert {:ok, map} =
+               SCIMConsumer.create_user(consumer, %{
+                 userName: "schemas-#{System.monotonic_time()}",
+                 name: %{givenName: "Test", familyName: "User"},
+                 emails: [%{value: "test@example.com", primary: true}]
+               })
+
+      assert map["schemas"] == ["urn:ietf:params:scim:schemas:core:2.0:User"]
+      assert is_binary(map["id"])
+      assert map["meta"]["resourceType"] == "User"
+    end
+
+    test "returns error for invalid token" do
+      org = organization_fixture()
+      consumer = SCIMConsumer.new(build_conn(), org, token: "invalid-token")
+
+      assert {:error, {:unexpected_status, 401, _body}} =
+               SCIMConsumer.create_user(consumer, %{
+                 userName: "nobody-#{System.monotonic_time()}",
+                 name: %{givenName: "No", familyName: "Body"},
+                 emails: [%{value: "nobody@example.com"}]
+               })
+    end
+  end
+
+  describe "create_group/2" do
+    test "POST /Groups sends correct Group schemas URI" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      name = "grp-schemas-#{System.monotonic_time()}"
+
+      assert {:ok, map} = SCIMConsumer.create_group(consumer, name)
+      assert map["schemas"] == ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+      assert is_binary(map["id"])
+      assert map["displayName"] == name
+    end
+  end
+
+  # ── PATCH Envelope ───────────────────────────────
+
+  describe "patch_user/3" do
+    test "PATCH body is correctly enveloped with PatchOp schema" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      user_name = "patch-env-#{System.monotonic_time()}"
+
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: user_name,
+          name: %{givenName: "Patch", familyName: "User"},
+          emails: [%{value: "patch@example.com"}]
+        })
+
+      assert {:ok, patched} =
+               SCIMConsumer.patch_user(consumer, user["id"], [
+                 %{"op" => "replace", "path" => "active", "value" => false}
+               ])
+
+      assert patched["active"] == false
+    end
+  end
+
+  # ── Response Validation ──────────────────────────
+
+  describe "validate_resource/1" do
+    test "rejects resource missing id field" do
+      invalid = %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "meta" => %{"resourceType" => "User", "location" => "http://example.com/Users/1"}
+      }
+
+      assert {:error, {:invalid_response, missing}} =
+               SCIMConsumer.validate_resource(invalid)
+
+      assert "id" in missing
+    end
+
+    test "rejects resource missing meta.location" do
+      invalid = %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id" => "1",
+        "meta" => %{"resourceType" => "User"}
+      }
+
+      assert {:error, {:invalid_response, missing}} =
+               SCIMConsumer.validate_resource(invalid)
+
+      assert "meta.location" in missing
+    end
+
+    test "rejects resource missing meta field entirely" do
+      invalid = %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id" => "1"
+      }
+
+      assert {:error, {:invalid_response, missing}} =
+               SCIMConsumer.validate_resource(invalid)
+
+      assert "meta.resourceType" in missing
+      assert "meta.location" in missing
+    end
+
+    test "rejects resource with empty schemas list" do
+      invalid = %{
+        "schemas" => [],
+        "id" => "1",
+        "meta" => %{"resourceType" => "User", "location" => "http://example.com/Users/1"}
+      }
+
+      assert {:error, {:invalid_response, missing}} =
+               SCIMConsumer.validate_resource(invalid)
+
+      assert "schemas" in missing
+    end
+
+    test "accepts valid resource with all required fields" do
+      valid = %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+        "id" => "1",
+        "meta" => %{"resourceType" => "User", "location" => "http://example.com/Users/1"},
+        "userName" => "test"
+      }
+
+      assert {:ok, ^valid} = SCIMConsumer.validate_resource(valid)
+    end
+  end
+
+  describe "validate_list_response/1" do
+    test "rejects response missing required ListResponse fields" do
+      invalid = %{"totalResults" => 0}
+
+      assert {:error, {:invalid_response, missing}} =
+               SCIMConsumer.validate_list_response(invalid)
+
+      assert "startIndex" in missing
+      assert "itemsPerPage" in missing
+      assert "Resources" in missing
+    end
+
+    test "accepts valid ListResponse" do
+      valid = %{
+        "totalResults" => 1,
+        "startIndex" => 1,
+        "itemsPerPage" => 25,
+        "Resources" => [
+          %{
+            "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "id" => "1",
+            "meta" => %{"resourceType" => "User", "location" => "http://example.com/Users/1"}
+          }
+        ]
+      }
+
+      assert {:ok, ^valid} = SCIMConsumer.validate_list_response(valid)
+    end
+  end
+
+  # ── ETag State Management ────────────────────────
+
+  describe "ETag round-trip" do
+    test "ETag from create is sent as If-Match on update" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      user_name = "etag-rt-#{System.monotonic_time()}"
+
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: user_name,
+          name: %{givenName: "Etag", familyName: "Round"},
+          emails: [%{value: "etag@example.com"}]
+        })
+
+      # update_user/3 automatically sends If-Match from cached ETag
+      assert {:ok, updated} =
+               SCIMConsumer.update_user(consumer, user["id"], %{active: false})
+
+      assert updated["active"] == false
+    end
+
+    test "stale ETag returns {:error, :conflict}" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      user_name = "etag-stale-#{System.monotonic_time()}"
+
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: user_name,
+          name: %{givenName: "Stale", familyName: "Etag"},
+          emails: [%{value: "stale@example.com"}]
+        })
+
+      # Corrupt the cached ETag so the server will reject it
+      Process.put(
+        {:scim_etag, org.id, "Users", user["id"]},
+        "W/\"00000000-0-0\""
+      )
+
+      assert {:error, :conflict} =
+               SCIMConsumer.update_user(consumer, user["id"], %{active: false})
+    end
+  end
+
+  # ── User Lifecycle ───────────────────────────────
+
+  describe "fetch_user/2" do
+    test "returns {:ok, user} for existing user", %{consumer: consumer} do
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: "fetch-#{System.monotonic_time()}",
+          name: %{givenName: "Fetch", familyName: "User"},
+          emails: [%{value: "fetch@example.com"}]
+        })
+
+      assert {:ok, fetched} = SCIMConsumer.fetch_user(consumer, user["id"])
+      assert fetched["id"] == user["id"]
+    end
+
+    test "returns {:error, :not_found} for nonexistent ID", %{consumer: consumer} do
+      assert {:error, :not_found} = SCIMConsumer.fetch_user(consumer, "nonexistent-id")
+    end
+  end
+
+  describe "update_user/3" do
+    test "returns {:error, :not_found} for nonexistent user", %{consumer: consumer} do
+      assert {:error, :not_found} = SCIMConsumer.update_user(consumer, "nope", %{active: false})
+    end
+  end
+
+  describe "delete_user/2" do
+    test "returns :ok for existing user", %{consumer: consumer} do
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: "del-#{System.monotonic_time()}",
+          name: %{givenName: "Del", familyName: "User"},
+          emails: [%{value: "del@example.com"}]
+        })
+
+      assert :ok = SCIMConsumer.delete_user(consumer, user["id"])
+    end
+
+    test "returns {:error, :not_found} for nonexistent ID", %{consumer: consumer} do
+      assert {:error, :not_found} = SCIMConsumer.delete_user(consumer, "nonexistent")
+    end
+
+    test "user remains fetchable with active: false after deletion", %{consumer: consumer} do
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: "del-soft-#{System.monotonic_time()}",
+          name: %{givenName: "Soft", familyName: "Delete"},
+          emails: [%{value: "soft@example.com"}]
+        })
+
+      assert :ok = SCIMConsumer.delete_user(consumer, user["id"])
+
+      assert {:ok, restored} = SCIMConsumer.fetch_user(consumer, user["id"])
+      assert restored["active"] == false
+    end
+  end
+
+  # ── List ─────────────────────────────────────────
+
+  describe "list_users/2" do
+    test "returns valid ListResponse", %{consumer: consumer} do
+      assert {:ok, list_resp} = SCIMConsumer.list_users(consumer)
+      assert is_map(list_resp)
+      assert is_integer(list_resp["totalResults"])
+      assert is_integer(list_resp["startIndex"])
+      assert is_integer(list_resp["itemsPerPage"])
+      assert is_list(list_resp["Resources"])
+    end
+
+    test "supports filter option (snake_case → SCIM query param)", %{consumer: consumer} do
+      user_name = "filter-list-#{System.monotonic_time()}"
+
+      SCIMConsumer.create_user(consumer, %{
+        userName: user_name,
+        name: %{givenName: "Filter", familyName: "List"},
+        emails: [%{value: "filter@example.com"}]
+      })
+
+      assert {:ok, list_resp} =
+               SCIMConsumer.list_users(consumer,
+                 filter: ~s(userName sw "filter-list"),
+                 count: 10,
+                 start_index: 1
+               )
+
+      assert list_resp["totalResults"] >= 1
+    end
+  end
+
+  describe "list_groups/2" do
+    test "returns valid ListResponse", %{consumer: consumer} do
+      assert {:ok, list_resp} = SCIMConsumer.list_groups(consumer)
+      assert is_map(list_resp)
+      assert is_integer(list_resp["totalResults"])
+    end
+  end
+
+  # ── Group Member Management ──────────────────────
+
+  describe "update_group_members/3" do
+    test "member add and remove via PATCH envelope" do
+      org = organization_fixture()
+      consumer = authenticated_consumer(org)
+
+      user_name = "member-uv-#{System.monotonic_time()}"
+
+      {:ok, user} =
+        SCIMConsumer.create_user(consumer, %{
+          userName: user_name,
+          name: %{givenName: "Member", familyName: "User"},
+          emails: [%{value: "member@example.com"}]
+        })
+
+      group_name = "grp-members-#{System.monotonic_time()}"
+
+      {:ok, group} = SCIMConsumer.create_group(consumer, group_name)
+
+      assert {:ok, with_member} =
+               SCIMConsumer.update_group_members(consumer, group["id"],
+                 add: [user["id"]],
+                 remove: []
+               )
+
+      members = with_member["members"] || []
+      assert match?([_], members)
+
+      assert {:ok, without_member} =
+               SCIMConsumer.update_group_members(consumer, group["id"],
+                 add: [],
+                 remove: [user["id"]]
+               )
+
+      updated_members = without_member["members"] || []
+      assert updated_members == []
+    end
+  end
+end

--- a/test/support/protocol_clients/oauth_client.ex
+++ b/test/support/protocol_clients/oauth_client.ex
@@ -171,6 +171,21 @@ defmodule AuthifyTest.OAuthClient do
     end
   end
 
+  def create_pat(user, org, opts \\ []) do
+    scopes = Keyword.get(opts, :scopes, Authify.Scopes.pat_scopes())
+
+    case Authify.Accounts.create_personal_access_token(user, org, %{
+           "name" => "Test PAT",
+           "scopes" => scopes
+         }) do
+      {:ok, token} ->
+        {:ok, token.plaintext_token}
+
+      {:error, changeset} ->
+        {:error, {:pat_creation_failed, changeset.errors}}
+    end
+  end
+
   def validate_id_token(%__MODULE__{app: app, org: org}, id_token, opts \\ []) do
     expected_nonce = Keyword.get(opts, :nonce)
 

--- a/test/support/protocol_clients/scim_consumer.ex
+++ b/test/support/protocol_clients/scim_consumer.ex
@@ -1,0 +1,303 @@
+defmodule AuthifyTest.SCIMConsumer do
+  @moduledoc false
+
+  @endpoint AuthifyWeb.Endpoint
+
+  import Plug.Conn, only: [get_resp_header: 2, put_req_header: 3]
+  import Phoenix.ConnTest
+
+  defstruct [:conn, :org, :token]
+
+  def new(conn, org, opts) do
+    %__MODULE__{conn: conn, org: org, token: Keyword.fetch!(opts, :token)}
+  end
+
+  # ── User Lifecycle ─────────────────────────────────────────
+
+  def create_user(%__MODULE__{} = consumer, attrs) do
+    body =
+      Enum.into(attrs, %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:User"]
+      })
+
+    resp = request(consumer, :post, "/Users", body: body)
+
+    case resp do
+      {:ok, conn} ->
+        with :ok <- cache_etag(consumer, "Users", id_from(resp), conn) do
+          handle_response(resp, :resource)
+        end
+
+      err ->
+        handle_response(err, :resource)
+    end
+  end
+
+  def fetch_user(%__MODULE__{} = consumer, id) do
+    resp = request(consumer, :get, "/Users/#{id}")
+    handle_response(resp, :resource)
+  end
+
+  def update_user(%__MODULE__{} = consumer, id, attrs) do
+    headers = if_etag_cached(consumer, "Users", id)
+
+    resp =
+      request(consumer, :put, "/Users/#{id}",
+        body: Enum.into(attrs, %{}),
+        headers: headers
+      )
+
+    case resp do
+      {:ok, conn} ->
+        with :ok <- cache_etag(consumer, "Users", id, conn) do
+          handle_response(resp, :resource)
+        end
+
+      err ->
+        handle_response(err, :resource)
+    end
+  end
+
+  def patch_user(%__MODULE__{} = consumer, id, operations) do
+    headers = if_etag_cached(consumer, "Users", id)
+
+    body = %{
+      "schemas" => ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+      "Operations" => operations
+    }
+
+    resp =
+      request(consumer, :patch, "/Users/#{id}",
+        body: body,
+        headers: headers
+      )
+
+    case resp do
+      {:ok, conn} ->
+        with :ok <- cache_etag(consumer, "Users", id, conn) do
+          handle_response(resp, :resource)
+        end
+
+      err ->
+        handle_response(err, :resource)
+    end
+  end
+
+  def delete_user(%__MODULE__{} = consumer, id) do
+    resp = request(consumer, :delete, "/Users/#{id}")
+    handle_response(resp, :deletion)
+  end
+
+  def list_users(%__MODULE__{} = consumer, opts \\ []) do
+    query = build_list_query(opts)
+    resp = request(consumer, :get, "/Users", query: query)
+    handle_response(resp, :list)
+  end
+
+  # ── Group Lifecycle ─────────────────────────────────────
+
+  def create_group(%__MODULE__{} = consumer, display_name, opts \\ []) do
+    body =
+      Enum.into(opts, %{
+        "schemas" => ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "displayName" => display_name
+      })
+
+    resp = request(consumer, :post, "/Groups", body: body)
+
+    case resp do
+      {:ok, conn} ->
+        with :ok <- cache_etag(consumer, "Groups", id_from(resp), conn) do
+          handle_response(resp, :resource)
+        end
+
+      err ->
+        handle_response(err, :resource)
+    end
+  end
+
+  def update_group_members(%__MODULE__{} = consumer, group_id, opts) do
+    add = Keyword.get(opts, :add, [])
+    remove = Keyword.get(opts, :remove, [])
+
+    operations =
+      for(id <- add, do: %{"op" => "add", "path" => "members", "value" => [%{"value" => id}]}) ++
+        for id <- remove, do: %{"op" => "remove", "path" => "members[value eq \"#{id}\"]"}
+
+    headers = if_etag_cached(consumer, "Groups", group_id)
+
+    body = %{
+      "schemas" => ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+      "Operations" => operations
+    }
+
+    resp =
+      request(consumer, :patch, "/Groups/#{group_id}",
+        body: body,
+        headers: headers
+      )
+
+    case resp do
+      {:ok, conn} ->
+        with :ok <- cache_etag(consumer, "Groups", group_id, conn) do
+          handle_response(resp, :resource)
+        end
+
+      err ->
+        handle_response(err, :resource)
+    end
+  end
+
+  def list_groups(%__MODULE__{} = consumer, opts \\ []) do
+    query = build_list_query(opts)
+    resp = request(consumer, :get, "/Groups", query: query)
+    handle_response(resp, :list)
+  end
+
+  # ── Response Validation ─────────────────────────────────
+
+  def validate_resource(resource) when is_map(resource) do
+    schemas = Map.get(resource, "schemas")
+    id = Map.get(resource, "id")
+    meta = Map.get(resource, "meta")
+
+    missing =
+      if(is_nil(schemas) or (is_list(schemas) and Enum.empty?(schemas)),
+        do: ["schemas"],
+        else: []
+      ) ++
+        if(is_nil(id), do: ["id"], else: []) ++
+        if is_nil(meta), do: ["meta.resourceType", "meta.location"], else: valid_meta_keys(meta)
+
+    if Enum.empty?(missing), do: {:ok, resource}, else: {:error, {:invalid_response, missing}}
+  end
+
+  def validate_list_response(response) when is_map(response) do
+    missing =
+      if(is_nil(Map.get(response, "totalResults")), do: ["totalResults"], else: []) ++
+        if(is_nil(Map.get(response, "startIndex")), do: ["startIndex"], else: []) ++
+        if(is_nil(Map.get(response, "itemsPerPage")), do: ["itemsPerPage"], else: []) ++
+        if is_nil(Map.get(response, "Resources")), do: ["Resources"], else: []
+
+    if Enum.empty?(missing), do: {:ok, response}, else: {:error, {:invalid_response, missing}}
+  end
+
+  # ── Private Helpers ───────────────────────────────────
+
+  defp request(consumer, method, path, opts \\ []) do
+    url = "/#{consumer.org.slug}/scim/v2#{path}"
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{consumer.token}")
+
+    conn =
+      if method in [:post, :put, :patch] do
+        put_req_header(conn, "content-type", "application/scim+json")
+      else
+        conn
+      end
+
+    conn =
+      if opts[:headers] do
+        Enum.reduce(opts[:headers], conn, fn {k, v}, c ->
+          put_req_header(c, String.downcase(k), v)
+        end)
+      else
+        conn
+      end
+
+    resp =
+      case method do
+        :get -> get(conn, url, opts[:query])
+        :post -> post(conn, url, opts[:body])
+        :put -> put(conn, url, opts[:body])
+        :patch -> patch(conn, url, opts[:body])
+        :delete -> delete(conn, url, opts[:query])
+      end
+
+    status = resp.status
+
+    if status in [200, 201, 204] do
+      {:ok, resp}
+    else
+      {:error, {conn, resp}}
+    end
+  end
+
+  defp if_etag_cached(consumer, type, id) do
+    case cached_etag(consumer, type, id) do
+      nil -> []
+      etag -> [{"if-match", etag}]
+    end
+  end
+
+  defp cache_etag(consumer, type, id, resp_conn) do
+    case get_resp_header(resp_conn, "etag") |> List.first() do
+      nil ->
+        :ok
+
+      etag ->
+        Process.put({:scim_etag, consumer.org.id, type, id}, etag)
+        :ok
+    end
+  end
+
+  defp cached_etag(consumer, type, id) do
+    Process.get({:scim_etag, consumer.org.id, type, id})
+  end
+
+  defp handle_response({:error, {_conn, resp}}, _type) do
+    body = resp.resp_body |> Jason.decode!()
+
+    case resp.status do
+      404 -> {:error, :not_found}
+      403 -> {:error, :forbidden}
+      409 -> {:error, :conflict}
+      412 -> {:error, :conflict}
+      _ -> {:error, {:unexpected_status, resp.status, body}}
+    end
+  end
+
+  defp handle_response({:ok, resp}, :resource) do
+    body = resp.resp_body |> Jason.decode!()
+    validate_resource(body)
+  end
+
+  defp handle_response({:ok, resp}, :deletion) do
+    if resp.status == 204, do: :ok, else: {:error, {:unexpected_status, resp.status, ""}}
+  end
+
+  defp handle_response({:ok, resp}, :list) do
+    body = resp.resp_body |> Jason.decode!()
+    validate_list_response(body)
+  end
+
+  defp build_list_query(opts) do
+    params =
+      opts
+      |> Enum.flat_map(fn
+        {:filter, v} -> [{"filter", v}]
+        {:count, v} -> [{"count", to_string(v)}]
+        {:start_index, v} -> [{"startIndex", to_string(v)}]
+        {:sort_by, v} -> [{"sortBy", v}]
+        {:sort_order, v} -> [{"sortOrder", v}]
+        _ -> []
+      end)
+      |> Map.new()
+
+    if map_size(params) == 0, do: nil, else: params
+  end
+
+  defp valid_meta_keys(meta) when is_map(meta) do
+    if(is_nil(Map.get(meta, "resourceType")), do: ["meta.resourceType"], else: []) ++
+      if is_nil(Map.get(meta, "location")), do: ["meta.location"], else: []
+  end
+
+  defp id_from({:ok, resp}) do
+    case get_resp_header(resp, "location") |> List.first() do
+      nil -> nil
+      loc -> String.split(loc, "/") |> List.last()
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **Fixes OAuth2 scope gap**: management API apps were restricted from having SCIM scopes (`scim:read`, `scim:write`), forcing all SCIM authentication to use PATs. This prevented proper OAuth2 `client_credentials` flows for SCIM consumers. Now `management_api_app` type applications can be granted SCIM scopes.
- **Adds `AuthifyTest.SCIMConsumer`**: a complete in-process SCIM 2.0 client for integration tests, covering the full user and group provisioning lifecycle with ETag concurrency control, PATCH operations, soft-delete behavior, and list/filter support.
- **Adds `OAuthClient.create_pat/3`**: test helper for creating Personal Access Tokens in unit tests.

## What was fixed in the consumer implementation

The initial implementation had several bugs caught by the tests:

- **204 DELETE crashed**: `request/4` only treated 200/201 as success; DELETE returns 204, which hit the error path and called `Jason.decode!("")` on an empty body
- **Error path bypassed `handle_response`**: mutating functions (`create_user`, `update_user`, etc.) returned raw `{conn, resp}` tuples instead of structured `{:error, reason}` tuples
- **`build_list_query` returned a string**: Phoenix.ConnTest treats a string params argument as a binary body (requires content-type), not query params; changed to return a map or nil
- **Stale ETag after PUT/PATCH**: `update_user`/`patch_user` used `id_from(resp)` which reads the `Location` response header — PUT/PATCH don't return `Location` (only POST does), so the ETag was cached under `nil` and the actual entry retained the stale ETag, causing 412 on subsequent calls
- **Wrong SCIM member PATCH format**: add operations sent `"value": "uuid"` (string) instead of `"value": [{"value": "uuid"}]` (list of objects); remove operations sent `"path": "members"` with a value instead of the filter path `members[value eq "uuid"]`

## Test plan

- [x] 101 tests in `test/protocol_clients/` pass with `async: true`
- [x] Integration test exercises the full OAuth2 `client_credentials` pipeline with `scim:read`/`scim:write` scopes (not a PAT), validating both the scope fix and the consumer end-to-end
- [x] `mix precommit` passes clean (credo, sobelow, full test suite)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)