### PR TITLE
fix: add rate limiting to OAuth token and userinfo endpoints

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -8,3 +8,8 @@ Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:17,6E55B0E
 Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:470,6EE1197
 XSS.SendResp: XSS in `send_resp`,lib/authify_web/controllers/saml_controller.ex:499,7ACD40E
 Config.CSRF: Missing CSRF Protections,lib/authify_web/router.ex:14,88CB4F
+
+Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:69,469F306
+Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:475,4AA393C
+Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:472,6D1EA51
+Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:80,7C3BA2

--- a/lib/authify_web/router.ex
+++ b/lib/authify_web/router.ex
@@ -40,6 +40,11 @@ defmodule AuthifyWeb.Router do
     plug :accepts, ["json"]
   end
 
+  pipeline :oauth_api do
+    plug :accepts, ["json"]
+    plug AuthifyWeb.Plugs.RateLimiter, :oauth_rate_limit
+  end
+
   pipeline :management_api do
     plug :accepts, ["json"]
     plug AuthifyWeb.Plugs.RateLimiter, :api_rate_limit
@@ -317,7 +322,7 @@ defmodule AuthifyWeb.Router do
   end
 
   scope "/:org_slug/oauth", AuthifyWeb do
-    pipe_through [:api, :organization]
+    pipe_through [:oauth_api, :organization]
 
     post "/token", OAuthController, :token
     get "/userinfo", OAuthController, :userinfo

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.16.4",
+      version: "0.16.5",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/authify_web/controllers/oauth_controller_test.exs
+++ b/test/authify_web/controllers/oauth_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule AuthifyWeb.OAuthControllerTest do
-  use AuthifyWeb.ConnCase, async: true
+  use AuthifyWeb.ConnCase, async: false
 
   import Authify.AccountsFixtures
   import Authify.OAuthFixtures
@@ -1261,16 +1261,42 @@ defmodule AuthifyWeb.OAuthControllerTest do
           assert true
       end
     end
+  end
 
-    @tag :skip
-    test "rate limiting for OAuth token endpoint", %{conn: conn, organization: organization} do
-      # Skipped: OAuth token endpoint needs rate limiting configured.
-      # See: https://github.com/authify/authify/issues/2
-      for _i <- 1..20 do
-        post(conn, ~p"/#{organization.slug}/oauth/token", %{})
+  describe "rate limiting" do
+    setup do
+      organization = organization_fixture()
+      Authify.RateLimitTestHelper.enable_rate_limiting()
+      %{organization: organization}
+    end
+
+    test "blocks excessive requests to OAuth token endpoint", %{
+      conn: conn,
+      organization: organization
+    } do
+      Authify.RateLimitTestHelper.clear_rate_limits()
+
+      for _i <- 1..60 do
+        result = post(conn, ~p"/#{organization.slug}/oauth/token", %{})
+        refute result.status == 429
       end
 
       conn = post(conn, ~p"/#{organization.slug}/oauth/token", %{})
+      assert response(conn, 429)
+    end
+
+    test "blocks excessive requests to OAuth userinfo endpoint", %{
+      conn: conn,
+      organization: organization
+    } do
+      Authify.RateLimitTestHelper.clear_rate_limits()
+
+      for _i <- 1..60 do
+        result = get(conn, ~p"/#{organization.slug}/oauth/userinfo")
+        refute result.status == 429
+      end
+
+      conn = get(conn, ~p"/#{organization.slug}/oauth/userinfo")
       assert response(conn, 429)
     end
   end


### PR DESCRIPTION
## Summary

- Adds a new `:oauth_api` pipeline with `RateLimiter` (`oauth_rate_limit`, 60 req/min per IP) to `router.ex`
- Switches `/:org_slug/oauth/token` and `/:org_slug/oauth/userinfo` from the unprotected `:api` pipeline to `:oauth_api`
- Unskips and rewrites the rate limiting test to follow the established `RateLimitTestHelper` pattern; adds a sibling test for the `userinfo` endpoint
- Bumps version to `0.16.5`

Closes #2

## Test Plan

- [x] New `"blocks excessive requests to OAuth token endpoint"` test passes (61st request returns 429)
- [x] New `"blocks excessive requests to OAuth userinfo endpoint"` test passes (61st request returns 429)
- [x] Full suite: 1915 tests, 0 failures
- [x] Pre-commit checks pass (credo, sobelow, format)