### PR TITLE
fix: clear expired JWT on auth error to prevent /login redirect loop

### DIFF
--- a/lib/authify_web/auth/error_handler.ex
+++ b/lib/authify_web/auth/error_handler.ex
@@ -8,6 +8,7 @@ defmodule AuthifyWeb.Auth.ErrorHandler do
 
   def auth_error(conn, {_type, _reason}, _opts) do
     conn
+    |> delete_session(:guardian_default_token)
     |> put_flash(:error, "Authentication required. Please log in.")
     |> redirect(to: "/login")
     |> halt()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.16.5",
+      version: "0.16.6",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/authify_web/controllers/session_controller_test.exs
+++ b/test/authify_web/controllers/session_controller_test.exs
@@ -12,6 +12,24 @@ defmodule AuthifyWeb.SessionControllerTest do
       assert html_response(conn, 200) =~ "Password"
     end
 
+    test "clears expired JWT from session to prevent redirect loop", %{conn: conn} do
+      # Simulate a browser that has an expired JWT in its session cookie
+      conn =
+        Plug.Test.init_test_session(conn, %{"guardian_default_token" => "expired.invalid.jwt"})
+
+      first_conn = get(conn, ~p"/login")
+
+      # Should redirect (auth error), not loop
+      assert redirected_to(first_conn) == "/login"
+
+      # The invalid JWT must be cleared from the session so the next request doesn't loop
+      assert get_session(first_conn, :guardian_default_token) == nil
+
+      # Following the redirect must render the login form (proves no loop)
+      second_conn = get(recycle(first_conn), ~p"/login")
+      assert html_response(second_conn, 200) =~ "Sign In"
+    end
+
     test "redirects to dashboard when user is already authenticated", %{conn: conn} do
       # Create organization and user
       slug = "test-org-#{System.unique_integer([:positive])}"


### PR DESCRIPTION
## Summary

- When a user's JWT expires, `Guardian.Plug.VerifySession` finds the stale token in the session cookie and calls the error handler, which redirected to `/login` without clearing it — causing an infinite redirect loop (every `/login` request re-triggered the same auth failure)
- Fixed by calling `delete_session(:guardian_default_token)` in `auth_error/3` so the redirect to `/login` arrives with a clean session
- `Guardian.Plug.sign_out` was intentionally avoided: it tries to revoke `current_token/1`, which is `nil` after a failed verification, causing `revoke/2` to fail and re-enter the error handler recursively
- Added regression test that injects an invalid JWT into the session, follows the redirect, and asserts the login form renders on the second request

## Test plan

- [x] New test `clears expired JWT from session to prevent redirect loop` passes — verifies session is cleared and the follow-up `/login` request returns 200
- [x] All 1916 existing tests pass, 0 failures
- [x] Confirmed root cause manually: private browsing (no JWT in session) worked fine; regular browsing with expired cookie looped — consistent with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)