### PR TITLE
feat: cryptographic signatures for audit logs (#23)

### DIFF
--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -1324,6 +1324,7 @@ defmodule Authify.Accounts do
         "saml_signing" -> "SAML Signing"
         "saml_encryption" -> "SAML Encryption"
         "oauth_signing" -> "OAuth Signing"
+        "audit_signing" -> "Audit Signing"
         _ -> "Certificate"
       end
 
@@ -1338,6 +1339,7 @@ defmodule Authify.Accounts do
         "saml_signing" -> "SAML Signing Certificate"
         "saml_encryption" -> "SAML Encryption Certificate"
         "oauth_signing" -> "OAuth Signing Certificate"
+        "audit_signing" -> "Audit Signing Certificate"
         _ -> "Certificate"
       end
 
@@ -1428,7 +1430,7 @@ defmodule Authify.Accounts do
     from(c in Certificate,
       where:
         c.organization_id == ^organization.id and c.usage == "saml_signing" and
-          c.is_active == true,
+          c.is_active == true and is_nil(c.deleted_at),
       limit: 1
     )
     |> Repo.one()
@@ -1441,7 +1443,7 @@ defmodule Authify.Accounts do
     from(c in Certificate,
       where:
         c.organization_id == ^organization.id and c.usage == "oauth_signing" and
-          c.is_active == true,
+          c.is_active == true and is_nil(c.deleted_at),
       limit: 1
     )
     |> Repo.one()
@@ -1458,6 +1460,49 @@ defmodule Authify.Accounts do
           "is_active" => true,
           "validity_days" => 365
         })
+
+      cert ->
+        {:ok, cert}
+    end
+  end
+
+  @doc """
+  Gets the active audit signing certificate for an organization by org ID.
+  """
+  def get_active_audit_signing_certificate(org_id) when is_integer(org_id) do
+    from(c in Certificate,
+      where:
+        c.organization_id == ^org_id and c.usage == "audit_signing" and
+          c.is_active == true and is_nil(c.deleted_at),
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  @doc """
+  Gets the active audit signing certificate, auto-generating one if none exists.
+  """
+  def get_or_generate_audit_signing_certificate(org_id) when is_integer(org_id) do
+    case get_active_audit_signing_certificate(org_id) do
+      nil ->
+        organization = Repo.get!(Organization, org_id)
+
+        result =
+          generate_certificate(organization, %{
+            "usage" => "audit_signing",
+            "is_active" => true,
+            "validity_days" => 365
+          })
+
+        if match?({:ok, _}, result) do
+          key_cache_mod = :"Elixir.Authify.AuditLog.KeyCache"
+
+          if function_exported?(key_cache_mod, :invalidate, 1) do
+            :erlang.apply(key_cache_mod, :invalidate, [org_id])
+          end
+        end
+
+        result
 
       cert ->
         {:ok, cert}

--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -1494,13 +1494,7 @@ defmodule Authify.Accounts do
             "validity_days" => 365
           })
 
-        if match?({:ok, _}, result) do
-          key_cache_mod = :"Elixir.Authify.AuditLog.KeyCache"
-
-          if function_exported?(key_cache_mod, :invalidate, 1) do
-            :erlang.apply(key_cache_mod, :invalidate, [org_id])
-          end
-        end
+        if match?({:ok, _}, result), do: Authify.AuditLog.KeyCache.invalidate(org_id)
 
         result
 

--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -1270,7 +1270,7 @@ defmodule Authify.Accounts do
   """
   def list_certificates(%Organization{id: org_id}) do
     from(c in Certificate,
-      where: c.organization_id == ^org_id,
+      where: c.organization_id == ^org_id and is_nil(c.deleted_at),
       order_by: [desc: c.inserted_at]
     )
     |> Repo.all()
@@ -1279,7 +1279,9 @@ defmodule Authify.Accounts do
   @doc """
   Gets a single certificate.
   """
-  def get_certificate!(id), do: Repo.get!(Certificate, id)
+  def get_certificate!(id) do
+    Repo.one!(from c in Certificate, where: c.id == ^id and is_nil(c.deleted_at))
+  end
 
   @doc """
   Creates a certificate.
@@ -1363,8 +1365,15 @@ defmodule Authify.Accounts do
   @doc """
   Gets a certificate with organization verification.
   """
-  def get_certificate!(id, organization) do
-    certificate = get_certificate!(id)
+  def get_certificate!(id, organization, opts \\ []) do
+    include_deleted = Keyword.get(opts, :include_deleted, false)
+
+    certificate =
+      if include_deleted do
+        Repo.get!(Certificate, id)
+      else
+        Repo.one!(from c in Certificate, where: c.id == ^id and is_nil(c.deleted_at))
+      end
 
     if certificate.organization_id == organization.id do
       certificate
@@ -1407,7 +1416,9 @@ defmodule Authify.Accounts do
   Deletes a certificate.
   """
   def delete_certificate(certificate) do
-    Repo.delete(certificate)
+    certificate
+    |> Ecto.Changeset.change(deleted_at: DateTime.utc_now() |> DateTime.truncate(:second))
+    |> Repo.update()
   end
 
   @doc """

--- a/lib/authify/accounts/certificate.ex
+++ b/lib/authify/accounts/certificate.ex
@@ -11,7 +11,7 @@ defmodule Authify.Accounts.Certificate do
 
   @valid_usages ["saml_signing", "saml_encryption", "oauth_signing"]
 
-  @derive {Jason.Encoder, except: [:__meta__, :organization, :private_key]}
+  @derive {Jason.Encoder, except: [:__meta__, :organization, :private_key, :deleted_at]}
   schema "certificates" do
     field :name, :string
     field :usage, :string
@@ -19,6 +19,7 @@ defmodule Authify.Accounts.Certificate do
     field :certificate, :string
     field :expires_at, :utc_datetime
     field :is_active, :boolean, default: false
+    field :deleted_at, :utc_datetime
 
     belongs_to :organization, Organization
 

--- a/lib/authify/accounts/certificate.ex
+++ b/lib/authify/accounts/certificate.ex
@@ -9,7 +9,7 @@ defmodule Authify.Accounts.Certificate do
 
   alias Authify.Accounts.Organization
 
-  @valid_usages ["saml_signing", "saml_encryption", "oauth_signing"]
+  @valid_usages ["saml_signing", "saml_encryption", "oauth_signing", "audit_signing"]
 
   @derive {Jason.Encoder, except: [:__meta__, :organization, :private_key, :deleted_at]}
   schema "certificates" do

--- a/lib/authify/application.ex
+++ b/lib/authify/application.ex
@@ -15,6 +15,7 @@ defmodule Authify.Application do
          [Application.get_env(:libcluster, :topologies, []), [name: Authify.ClusterSupervisor]]},
         Authify.RateLimit,
         Authify.Configurations.Cache,
+        Authify.AuditLog.KeyCache,
         {Phoenix.PubSub, name: Authify.PubSub},
         {Oban, Application.fetch_env!(:authify, Oban)}
       ] ++

--- a/lib/authify/audit_log.ex
+++ b/lib/authify/audit_log.ex
@@ -17,6 +17,8 @@ defmodule Authify.AuditLog do
   import Ecto.Query, warn: false
 
   alias Authify.AuditLog.Event
+  alias Authify.AuditLog.Signer
+  alias Authify.Configurations
   alias Authify.Repo
 
   @doc """
@@ -66,14 +68,10 @@ defmodule Authify.AuditLog do
   end
 
   def log_event(event_type, attrs) when is_binary(event_type) do
+    org_id = Map.get(attrs, :organization_id) || Map.get(attrs, "organization_id")
     attrs = Map.put(attrs, :event_type, event_type)
 
-    result =
-      %Event{}
-      |> Event.changeset(attrs)
-      |> Repo.insert()
-
-    case result do
+    case %Event{} |> Event.changeset(attrs) |> Repo.insert() do
       {:ok, event} ->
         :telemetry.execute(
           [:authify, :audit_log, :event],
@@ -89,11 +87,11 @@ defmodule Authify.AuditLog do
           }
         )
 
-      _ ->
-        :ok
-    end
+        {:ok, maybe_sign_event(event, org_id)}
 
-    result
+      error ->
+        error
+    end
   end
 
   @doc """
@@ -376,6 +374,24 @@ defmodule Authify.AuditLog do
     |> Repo.all()
     |> Map.new()
   end
+
+  defp maybe_sign_event(event, org_id) when is_integer(org_id) do
+    if Configurations.get_setting("Organization", org_id, :sign_audit_logs) do
+      case Signer.sign(event, org_id) do
+        {:ok, signature, cert_id} ->
+          event
+          |> Event.signature_changeset(%{signature: signature, signing_certificate_id: cert_id})
+          |> Repo.update!()
+
+        {:error, _reason} ->
+          event
+      end
+    else
+      event
+    end
+  end
+
+  defp maybe_sign_event(event, _org_id), do: event
 
   @doc """
   Gets a single event by ID, raising if not found.

--- a/lib/authify/audit_log/event.ex
+++ b/lib/authify/audit_log/event.ex
@@ -62,6 +62,8 @@ defmodule Authify.AuditLog.Event do
              :outcome,
              :metadata,
              :organization_id,
+             :signature,
+             :signing_certificate_id,
              :inserted_at
            ]}
 
@@ -76,6 +78,8 @@ defmodule Authify.AuditLog.Event do
     field :user_agent, :string
     field :outcome, :string
     field :metadata, :map
+    field :signature, :string
+    field :signing_certificate_id, :integer
 
     belongs_to :organization, Organization
 
@@ -103,6 +107,11 @@ defmodule Authify.AuditLog.Event do
     |> validate_inclusion(:actor_type, Enum.map(@actor_types, &to_string/1))
     |> validate_inclusion(:outcome, Enum.map(@outcome_types, &to_string/1))
     |> foreign_key_constraint(:organization_id)
+  end
+
+  @doc false
+  def signature_changeset(event, attrs) do
+    cast(event, attrs, [:signature, :signing_certificate_id])
   end
 
   @doc """

--- a/lib/authify/audit_log/key_cache.ex
+++ b/lib/authify/audit_log/key_cache.ex
@@ -1,0 +1,43 @@
+defmodule Authify.AuditLog.KeyCache do
+  @moduledoc """
+  ETS-backed cache for decoded audit signing private keys, keyed by organization ID.
+
+  Avoids a DB round-trip + key decryption on every audit event write for orgs
+  with sign_audit_logs enabled. Entries are invalidated when a new audit_signing
+  certificate is generated for an org.
+  """
+
+  use GenServer
+
+  @table :audit_signing_key_cache
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @doc "Returns `{:ok, %{private_key: key, cert_id: id}}` or `:miss`."
+  def get(org_id) do
+    case :ets.lookup(@table, org_id) do
+      [{^org_id, entry}] -> {:ok, entry}
+      [] -> :miss
+    end
+  end
+
+  @doc "Stores a decoded private key and its certificate ID for an org."
+  def put(org_id, private_key, cert_id) do
+    :ets.insert(@table, {org_id, %{private_key: private_key, cert_id: cert_id}})
+    :ok
+  end
+
+  @doc "Removes the cached key for an org (call when a new audit_signing cert is created)."
+  def invalidate(org_id) do
+    :ets.delete(@table, org_id)
+    :ok
+  end
+
+  @impl true
+  def init(_opts) do
+    :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+    {:ok, %{}}
+  end
+end

--- a/lib/authify/audit_log/signer.ex
+++ b/lib/authify/audit_log/signer.ex
@@ -1,0 +1,109 @@
+defmodule Authify.AuditLog.Signer do
+  @moduledoc """
+  Signs and verifies audit log events using RSA-SHA256.
+
+  The canonical payload is a JSON object with a fixed set of fields in
+  alphabetical key order, with nil values encoded as JSON null (never omitted).
+  This determinism ensures the payload can be reconstructed independently for
+  offline verification.
+  """
+
+  alias Authify.Accounts
+  alias Authify.AuditLog.Event
+  alias Authify.AuditLog.KeyCache
+
+  @doc """
+  Returns a deterministic JSON binary for the signable fields of an event.
+
+  Keys are in alphabetical order; nil values are included as JSON null.
+  """
+  def canonical_payload(%Event{} = event) do
+    # Pairs listed in alphabetical key order — order is intentional
+    pairs = [
+      {"actor_id", event.actor_id},
+      {"actor_name", event.actor_name},
+      {"actor_type", event.actor_type},
+      {"event_type", event.event_type},
+      {"inserted_at", DateTime.to_iso8601(event.inserted_at)},
+      {"ip_address", event.ip_address},
+      {"metadata", event.metadata},
+      {"organization_id", event.organization_id},
+      {"outcome", event.outcome},
+      {"resource_id", event.resource_id},
+      {"resource_type", event.resource_type},
+      {"user_agent", event.user_agent}
+    ]
+
+    inner =
+      Enum.map_join(pairs, ",", fn {k, v} ->
+        Jason.encode!(k) <> ":" <> Jason.encode!(v)
+      end)
+
+    "{#{inner}}"
+  end
+
+  @doc """
+  Signs an event for the given org_id using the org's active audit signing cert.
+
+  Returns `{:ok, base64_signature, cert_id}` or `{:error, reason}`.
+  Caches the decoded private key in `KeyCache` to avoid repeat DB lookups.
+  """
+  def sign(%Event{} = event, org_id) when is_integer(org_id) do
+    with {:ok, private_key, cert_id} <- fetch_or_cache_key(org_id) do
+      payload = canonical_payload(event)
+      signature_bytes = :public_key.sign(payload, :sha256, private_key)
+      {:ok, Base.encode64(signature_bytes), cert_id}
+    end
+  end
+
+  @doc """
+  Verifies a signed event against the PEM of the certificate that signed it.
+
+  Returns `:ok`, `{:error, :invalid}`, or `{:error, :unsigned}`.
+  """
+  def verify(%Event{signature: nil}, _cert_pem), do: {:error, :unsigned}
+
+  def verify(%Event{} = event, cert_pem) when is_binary(cert_pem) do
+    with {:ok, cert} <- decode_certificate(cert_pem),
+         public_key <- X509.Certificate.public_key(cert),
+         {:ok, sig_bytes} <- Base.decode64(event.signature) do
+      payload = canonical_payload(event)
+
+      if :public_key.verify(payload, :sha256, sig_bytes, public_key) do
+        :ok
+      else
+        {:error, :invalid}
+      end
+    else
+      :error -> {:error, :invalid}
+      {:error, _} -> {:error, :invalid}
+    end
+  end
+
+  defp fetch_or_cache_key(org_id) do
+    case KeyCache.get(org_id) do
+      {:ok, %{private_key: private_key, cert_id: cert_id}} ->
+        {:ok, private_key, cert_id}
+
+      :miss ->
+        with {:ok, cert} <- Accounts.get_or_generate_audit_signing_certificate(org_id),
+             {:ok, pem} <- Accounts.decrypt_certificate_private_key(cert),
+             {:ok, private_key} <- decode_private_key(pem) do
+          KeyCache.put(org_id, private_key, cert.id)
+          {:ok, private_key, cert.id}
+        end
+    end
+  end
+
+  defp decode_private_key(pem) do
+    {:ok, X509.PrivateKey.from_pem!(pem)}
+  rescue
+    e -> {:error, e}
+  end
+
+  defp decode_certificate(pem) do
+    {:ok, X509.Certificate.from_pem!(pem)}
+  rescue
+    e -> {:error, e}
+  end
+end

--- a/lib/authify/configurations/schemas/organization.ex
+++ b/lib/authify/configurations/schemas/organization.ex
@@ -61,6 +61,18 @@ defmodule Authify.Configurations.Schemas.Organization do
           validation_fn: nil
         },
         %{
+          name: :sign_audit_logs,
+          description:
+            "Cryptographically sign audit log events with the organization's audit signing " <>
+              "certificate for compliance verification. When enabled, each new audit event is " <>
+              "signed with RSA-SHA256; the signature and a link to the public certificate are " <>
+              "included in API responses.",
+          value_type: :boolean,
+          default_value: false,
+          required: false,
+          validation_fn: nil
+        },
+        %{
           name: :scim_inbound_provisioning_enabled,
           description:
             "Enable SCIM 2.0 Service Provider endpoints - allows external identity providers and HR systems to provision users and groups into this organization",

--- a/lib/authify_web/controllers/api/audit_logs_controller.ex
+++ b/lib/authify_web/controllers/api/audit_logs_controller.ex
@@ -49,7 +49,8 @@ defmodule AuthifyWeb.API.AuditLogsController do
 
         render_collection_response(conn, audit_logs,
           resource_type: "audit_log",
-          page_info: page_info
+          page_info: page_info,
+          extra_links_fn: signing_cert_links_fn(organization.slug)
         )
 
       {:error, response} ->
@@ -70,7 +71,10 @@ defmodule AuthifyWeb.API.AuditLogsController do
 
         case AuditLog.get_event(id, organization_id: organization.id) do
           {:ok, event} ->
-            render_api_response(conn, event, resource_type: "audit_log")
+            render_api_response(conn, event,
+              resource_type: "audit_log",
+              extra_links_fn: signing_cert_links_fn(organization.slug)
+            )
 
           {:error, :not_found} ->
             render_error_response(
@@ -110,6 +114,19 @@ defmodule AuthifyWeb.API.AuditLogsController do
     case DateTime.from_iso8601(date_string) do
       {:ok, datetime, _offset} -> Keyword.put(opts, key, datetime)
       {:error, _} -> opts
+    end
+  end
+
+  defp signing_cert_links_fn(org_slug) do
+    fn event ->
+      if event.signing_certificate_id do
+        %{
+          signing_certificate:
+            "/#{org_slug}/api/certificates/#{event.signing_certificate_id}/download/certificate"
+        }
+      else
+        %{}
+      end
     end
   end
 end

--- a/lib/authify_web/controllers/api/base_controller.ex
+++ b/lib/authify_web/controllers/api/base_controller.ex
@@ -227,9 +227,17 @@ defmodule AuthifyWeb.API.BaseController do
     org_slug = get_org_slug(conn)
     base_path = "/#{org_slug}/api/#{pluralize_resource_type(resource_type)}"
 
-    %{
+    base = %{
       self: "#{base_path}/#{resource.id}"
     }
+
+    extra =
+      case opts[:extra_links_fn] do
+        nil -> %{}
+        fun -> fun.(resource)
+      end
+
+    Map.merge(base, extra)
   end
 
   defp pluralize_resource_type("organization"), do: "organization"

--- a/lib/authify_web/controllers/api/certificates_controller.ex
+++ b/lib/authify_web/controllers/api/certificates_controller.ex
@@ -393,8 +393,13 @@ defmodule AuthifyWeb.API.CertificatesController do
       :ok ->
         organization = conn.assigns.current_organization
 
+        # Public certificate PEM must remain accessible even for soft-deleted certs
+        # (needed for offline verification of signed audit log events)
+        include_deleted = type == "certificate"
+
         try do
-          certificate = Accounts.get_certificate!(id, organization)
+          certificate =
+            Accounts.get_certificate!(id, organization, include_deleted: include_deleted)
 
           {content, filename} =
             case type do

--- a/lib/authify_web/controllers/api/open_api/paths/audit_logs.ex
+++ b/lib/authify_web/controllers/api/open_api/paths/audit_logs.ex
@@ -128,7 +128,19 @@ defmodule AuthifyWeb.API.OpenAPI.Paths.AuditLogs do
                               ip_address: %{type: "string"},
                               user_agent: %{type: "string"},
                               metadata: %{type: "object"},
-                              inserted_at: %{type: "string", format: "date-time"}
+                              inserted_at: %{type: "string", format: "date-time"},
+                              signature: %{
+                                type: :string,
+                                nullable: true,
+                                description:
+                                  "Base64-encoded RSA-SHA256 signature of the canonical event payload. Null if signing is not enabled for this organization."
+                              },
+                              signing_certificate_id: %{
+                                type: :integer,
+                                nullable: true,
+                                description:
+                                  "ID of the certificate used to sign this event. Retrieve the public PEM via the signing_certificate link for offline verification."
+                              }
                             }
                           }
                         }
@@ -204,7 +216,31 @@ defmodule AuthifyWeb.API.OpenAPI.Paths.AuditLogs do
                             ip_address: %{type: "string"},
                             user_agent: %{type: "string"},
                             metadata: %{type: "object"},
-                            inserted_at: %{type: "string", format: "date-time"}
+                            inserted_at: %{type: "string", format: "date-time"},
+                            signature: %{
+                              type: :string,
+                              nullable: true,
+                              description:
+                                "Base64-encoded RSA-SHA256 signature of the canonical event payload. Null if signing is not enabled for this organization."
+                            },
+                            signing_certificate_id: %{
+                              type: :integer,
+                              nullable: true,
+                              description:
+                                "ID of the certificate used to sign this event. Retrieve the public PEM via the signing_certificate link for offline verification."
+                            }
+                          }
+                        },
+                        links: %{
+                          type: "object",
+                          properties: %{
+                            self: %{type: "string"},
+                            signing_certificate: %{
+                              type: :string,
+                              nullable: true,
+                              description:
+                                "URL to download the public certificate PEM used to sign this event. Present only when signature is non-null."
+                            }
                           }
                         }
                       }

--- a/lib/authify_web/controllers/api/open_api/schemas/certificates.ex
+++ b/lib/authify_web/controllers/api/open_api/schemas/certificates.ex
@@ -108,7 +108,7 @@ defmodule AuthifyWeb.API.OpenAPI.Schemas.Certificates do
         name: %{type: "string", description: "Certificate name"},
         usage: %{
           type: "string",
-          enum: ["saml_signing", "saml_encryption", "oauth_signing"],
+          enum: ["saml_signing", "saml_encryption", "oauth_signing", "audit_signing"],
           description: "Certificate usage type"
         },
         certificate: %{
@@ -177,7 +177,7 @@ defmodule AuthifyWeb.API.OpenAPI.Schemas.Certificates do
             name: %{type: "string", description: "Certificate name"},
             usage: %{
               type: "string",
-              enum: ["saml_signing", "saml_encryption", "oauth_signing"],
+              enum: ["saml_signing", "saml_encryption", "oauth_signing", "audit_signing"],
               description: "Certificate usage type"
             },
             generate_new: %{

--- a/lib/authify_web/controllers/api/open_api/schemas/organizations.ex
+++ b/lib/authify_web/controllers/api/open_api/schemas/organizations.ex
@@ -188,7 +188,13 @@ defmodule AuthifyWeb.API.OpenAPI.Schemas.Organizations do
                   format: "email",
                   description: "Organization contact email"
                 },
-                logo_url: %{type: "string", format: "uri", description: "Organization logo URL"}
+                logo_url: %{type: "string", format: "uri", description: "Organization logo URL"},
+                sign_audit_logs: %{
+                  type: "boolean",
+                  description:
+                    "When true, each new audit event is signed with the organization's audit_signing certificate using RSA-SHA256. Signatures are included in API responses and can be verified offline using the linked public certificate PEM.",
+                  default: false
+                }
               }
             }
           ]

--- a/lib/authify_web/controllers/audit_logs_html/index.html.heex
+++ b/lib/authify_web/controllers/audit_logs_html/index.html.heex
@@ -145,6 +145,7 @@
                 <th>Actor</th>
                 <th>Outcome</th>
                 <th>IP Address</th>
+                <th></th>
                 <th>Details</th>
               </tr>
             </thead>
@@ -172,6 +173,16 @@
                   </td>
                   <td class="text-nowrap">
                     {event.ip_address || "N/A"}
+                  </td>
+                  <td class="text-center">
+                    <%= if event.signature do %>
+                      <i
+                        class="bi bi-shield-check text-success"
+                        title="Cryptographically signed"
+                        style="font-size: 1.1rem;"
+                      >
+                      </i>
+                    <% end %>
                   </td>
                   <td>
                     <a

--- a/lib/authify_web/controllers/audit_logs_html/show.html.heex
+++ b/lib/authify_web/controllers/audit_logs_html/show.html.heex
@@ -170,6 +170,62 @@
             </div>
           </div>
         <% end %>
+
+        <div class="card mb-4">
+          <div class="card-header d-flex align-items-center gap-2">
+            <i class="bi bi-shield-lock"></i>
+            <h5 class="mb-0">Cryptographic Signature</h5>
+          </div>
+          <div class="card-body">
+            <%= if @event.signature do %>
+              <div class="mb-3">
+                <span class="badge bg-success">
+                  <i class="bi bi-shield-check me-1"></i>Signed
+                </span>
+              </div>
+              <div class="mb-3">
+                <strong>Signature:</strong>
+                <div class="mt-1 d-flex align-items-start gap-2">
+                  <code
+                    id="sig-value"
+                    class="text-break small"
+                    style="word-break: break-all; font-size: 0.75rem;"
+                  >
+                    {@event.signature}
+                  </code>
+                  <button
+                    class="btn btn-sm btn-outline-secondary flex-shrink-0"
+                    onclick={"navigator.clipboard.writeText('#{@event.signature}')"}
+                    title="Copy full signature"
+                  >
+                    <i class="bi bi-clipboard"></i>
+                  </button>
+                </div>
+              </div>
+              <div class="mb-0">
+                <strong>Signing Certificate:</strong>
+                <div class="mt-1">
+                  <a
+                    href={
+                      ~p"/#{@organization.slug}/api/certificates/#{@event.signing_certificate_id}/download/certificate"
+                    }
+                    class="btn btn-sm btn-outline-primary"
+                  >
+                    <i class="bi bi-download me-1"></i>Download PEM
+                  </a>
+                  <small class="text-muted ms-2">for offline verification</small>
+                </div>
+              </div>
+            <% else %>
+              <span class="badge bg-secondary">
+                <i class="bi bi-shield me-1"></i>Unsigned
+              </span>
+              <p class="text-muted small mt-2 mb-0">
+                This event was recorded before cryptographic signing was enabled, or signing is not currently active for this organization.
+              </p>
+            <% end %>
+          </div>
+        </div>
       </div>
     </div>
   </:main>

--- a/lib/authify_web/controllers/configuration_html/show.html.heex
+++ b/lib/authify_web/controllers/configuration_html/show.html.heex
@@ -253,6 +253,26 @@
                       class="form-check-input"
                       type="checkbox"
                       role="switch"
+                      id="sign_audit_logs"
+                      name="settings[sign_audit_logs]"
+                      value="true"
+                      checked={@settings[:sign_audit_logs] == true}
+                    />
+                    <label class="form-check-label" for="sign_audit_logs">
+                      <strong>Sign Audit Logs</strong>
+                    </label>
+                  </div>
+                  <small class="text-muted ms-4">
+                    Cryptographically sign each audit log event with this organization's audit signing certificate (RSA-SHA256). Signatures are included in API responses and can be verified offline using the linked public certificate PEM.
+                  </small>
+                </div>
+
+                <div class="mb-4">
+                  <div class="form-check form-switch">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
                       id="scim_inbound_provisioning_enabled"
                       name="settings[scim_inbound_provisioning_enabled]"
                       value="true"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.16.7",
+      version: "0.17.0",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260521044435_add_deleted_at_to_certificates.exs
+++ b/priv/repo/migrations/20260521044435_add_deleted_at_to_certificates.exs
@@ -1,0 +1,11 @@
+defmodule Authify.Repo.Migrations.AddDeletedAtToCertificates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:certificates) do
+      add :deleted_at, :utc_datetime, null: true
+    end
+
+    create index(:certificates, [:deleted_at])
+  end
+end

--- a/priv/repo/migrations/20260521162102_add_signature_to_audit_events.exs
+++ b/priv/repo/migrations/20260521162102_add_signature_to_audit_events.exs
@@ -1,0 +1,12 @@
+defmodule Authify.Repo.Migrations.AddSignatureToAuditEvents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_events) do
+      add :signature, :text, null: true
+      add :signing_certificate_id, references(:certificates, on_delete: :nothing), null: true
+    end
+
+    create index(:audit_events, [:signing_certificate_id])
+  end
+end

--- a/test/authify/accounts_test.exs
+++ b/test/authify/accounts_test.exs
@@ -1336,6 +1336,37 @@ defmodule Authify.AccountsTest do
     end
   end
 
+  describe "audit signing certificate" do
+    setup do
+      organization = organization_fixture()
+      %{organization: organization}
+    end
+
+    test "get_or_generate_audit_signing_certificate/1 generates cert if none exists", %{
+      organization: org
+    } do
+      {:ok, cert} = Accounts.get_or_generate_audit_signing_certificate(org.id)
+
+      assert cert.usage == "audit_signing"
+      assert cert.is_active == true
+      assert cert.organization_id == org.id
+    end
+
+    test "get_or_generate_audit_signing_certificate/1 returns existing active cert", %{
+      organization: org
+    } do
+      {:ok, cert1} = Accounts.get_or_generate_audit_signing_certificate(org.id)
+      {:ok, cert2} = Accounts.get_or_generate_audit_signing_certificate(org.id)
+
+      assert cert1.id == cert2.id
+    end
+
+    test "generate_certificate/2 accepts audit_signing usage", %{organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "audit_signing"})
+      assert cert.usage == "audit_signing"
+    end
+  end
+
   describe "groups" do
     setup do
       {:ok, org} = Accounts.create_organization(valid_org_attrs())

--- a/test/authify/accounts_test.exs
+++ b/test/authify/accounts_test.exs
@@ -1279,6 +1279,63 @@ defmodule Authify.AccountsTest do
     end
   end
 
+  describe "certificate soft-delete" do
+    setup do
+      organization = organization_fixture()
+      %{organization: organization}
+    end
+
+    test "delete_certificate/1 sets deleted_at and does not remove the row", %{organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+
+      {:ok, deleted} = Accounts.delete_certificate(cert)
+
+      assert deleted.deleted_at != nil
+      # Row still exists in DB
+      assert Authify.Repo.get(Authify.Accounts.Certificate, cert.id) != nil
+    end
+
+    test "list_certificates/1 excludes soft-deleted certificates", %{organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      certs = Accounts.list_certificates(org)
+      ids = Enum.map(certs, & &1.id)
+      refute cert.id in ids
+    end
+
+    test "get_certificate!/1 raises for soft-deleted certificate", %{organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Accounts.get_certificate!(cert.id)
+      end
+    end
+
+    test "get_certificate!/2 with include_deleted: true finds soft-deleted cert", %{
+      organization: org
+    } do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      found = Accounts.get_certificate!(cert.id, org, include_deleted: true)
+      assert found.id == cert.id
+      assert found.deleted_at != nil
+    end
+
+    test "get_certificate!/2 without include_deleted raises for soft-deleted cert", %{
+      organization: org
+    } do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Accounts.get_certificate!(cert.id, org)
+      end
+    end
+  end
+
   describe "groups" do
     setup do
       {:ok, org} = Accounts.create_organization(valid_org_attrs())

--- a/test/authify/audit_log/key_cache_test.exs
+++ b/test/authify/audit_log/key_cache_test.exs
@@ -1,0 +1,35 @@
+defmodule Authify.AuditLog.KeyCacheTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  alias Authify.AuditLog.KeyCache
+
+  setup do
+    :ok
+  end
+
+  test "get/1 returns :miss when org not in cache" do
+    assert KeyCache.get(999_999) == :miss
+  end
+
+  test "put/3 and get/1 round-trip" do
+    org_id = System.unique_integer([:positive])
+    fake_key = :crypto.generate_key(:rsa, {2048, 65_537}) |> elem(0)
+
+    :ok = KeyCache.put(org_id, fake_key, 42)
+    {:ok, entry} = KeyCache.get(org_id)
+
+    assert entry.cert_id == 42
+    assert entry.private_key == fake_key
+  end
+
+  test "invalidate/1 removes entry from cache" do
+    org_id = System.unique_integer([:positive])
+    fake_key = :crypto.generate_key(:rsa, {2048, 65_537}) |> elem(0)
+
+    :ok = KeyCache.put(org_id, fake_key, 99)
+    :ok = KeyCache.invalidate(org_id)
+
+    assert KeyCache.get(org_id) == :miss
+  end
+end

--- a/test/authify/audit_log/signer_test.exs
+++ b/test/authify/audit_log/signer_test.exs
@@ -1,0 +1,104 @@
+defmodule Authify.AuditLog.SignerTest do
+  @moduledoc false
+  use Authify.DataCase, async: true
+
+  alias Authify.AuditLog.Event
+  alias Authify.AuditLog.Signer
+
+  import Authify.AccountsFixtures
+
+  defp build_event(org_id) do
+    %Event{
+      id: 1,
+      event_type: "login_success",
+      actor_type: "user",
+      actor_id: 42,
+      actor_name: "Jane Doe",
+      resource_type: nil,
+      resource_id: nil,
+      ip_address: "127.0.0.1",
+      user_agent: "TestAgent/1.0",
+      outcome: "success",
+      metadata: %{"foo" => "bar"},
+      organization_id: org_id,
+      inserted_at: ~U[2026-05-20 12:00:00Z]
+    }
+  end
+
+  describe "canonical_payload/1" do
+    test "produces same output regardless of struct field order" do
+      org = organization_fixture()
+      event = build_event(org.id)
+
+      payload1 = Signer.canonical_payload(event)
+      payload2 = Signer.canonical_payload(event)
+
+      assert payload1 == payload2
+    end
+
+    test "includes null for nil fields" do
+      org = organization_fixture()
+      event = build_event(org.id)
+
+      payload = Signer.canonical_payload(event)
+      decoded = Jason.decode!(payload)
+
+      assert Map.has_key?(decoded, "resource_type")
+      assert decoded["resource_type"] == nil
+    end
+
+    test "keys are in alphabetical order" do
+      org = organization_fixture()
+      event = build_event(org.id)
+
+      payload = Signer.canonical_payload(event)
+      decoded = Jason.decode!(payload)
+      keys = Map.keys(decoded)
+
+      assert keys == Enum.sort(keys)
+    end
+  end
+
+  describe "sign/2 and verify/2" do
+    setup do
+      org = organization_fixture()
+      {:ok, cert} = Authify.Accounts.get_or_generate_audit_signing_certificate(org.id)
+      %{org: org, cert: cert}
+    end
+
+    test "sign/2 returns base64 signature and cert_id", %{org: org, cert: cert} do
+      event = build_event(org.id)
+
+      {:ok, signature, cert_id} = Signer.sign(event, org.id)
+
+      assert is_binary(signature)
+      assert Base.decode64(signature) != :error
+      assert cert_id == cert.id
+    end
+
+    test "verify/2 returns :ok for a properly signed event", %{org: org, cert: cert} do
+      event = build_event(org.id)
+      {:ok, signature, _cert_id} = Signer.sign(event, org.id)
+
+      signed_event = %{event | signature: signature}
+
+      assert :ok == Signer.verify(signed_event, cert.certificate)
+    end
+
+    test "verify/2 returns {:error, :invalid} when payload is tampered", %{org: org, cert: cert} do
+      event = build_event(org.id)
+      {:ok, signature, _} = Signer.sign(event, org.id)
+
+      tampered = %{event | signature: signature, actor_name: "Hacker"}
+
+      assert {:error, :invalid} == Signer.verify(tampered, cert.certificate)
+    end
+
+    test "verify/2 returns {:error, :unsigned} for event with nil signature", %{cert: cert} do
+      org = organization_fixture()
+      event = build_event(org.id)
+
+      assert {:error, :unsigned} == Signer.verify(event, cert.certificate)
+    end
+  end
+end

--- a/test/authify/audit_log_test.exs
+++ b/test/authify/audit_log_test.exs
@@ -394,6 +394,59 @@ defmodule Authify.AuditLogTest do
     end
   end
 
+  describe "audit log signing" do
+    setup do
+      org = organization_fixture()
+
+      base_attrs = %{
+        organization_id: org.id,
+        actor_type: "user",
+        actor_id: 1,
+        outcome: "success"
+      }
+
+      %{org: org, base_attrs: base_attrs}
+    end
+
+    test "log_event/2 does NOT sign when sign_audit_logs is false (default)", %{base_attrs: attrs} do
+      {:ok, event} = AuditLog.log_event(:login_success, attrs)
+
+      assert event.signature == nil
+      assert event.signing_certificate_id == nil
+    end
+
+    test "log_event/2 signs event when sign_audit_logs is true", %{org: org, base_attrs: attrs} do
+      Authify.Configurations.set_organization_setting(org, :sign_audit_logs, true)
+
+      {:ok, event} = AuditLog.log_event(:login_success, attrs)
+
+      assert is_binary(event.signature)
+      assert is_integer(event.signing_certificate_id)
+    end
+
+    test "signed event passes verification", %{org: org, base_attrs: attrs} do
+      Authify.Configurations.set_organization_setting(org, :sign_audit_logs, true)
+
+      {:ok, event} = AuditLog.log_event(:login_success, attrs)
+      {:ok, cert} = Authify.Accounts.get_or_generate_audit_signing_certificate(org.id)
+
+      assert :ok == Authify.AuditLog.Signer.verify(event, cert.certificate)
+    end
+
+    test "log_event_async/2 signs event when sign_audit_logs is true", %{
+      org: org,
+      base_attrs: attrs
+    } do
+      Authify.Configurations.set_organization_setting(org, :sign_audit_logs, true)
+
+      :ok = AuditLog.log_event_async(:login_success, attrs)
+
+      # In test env, async falls back to sync — query the DB
+      [event] = AuditLog.list_events(organization_id: org.id)
+      assert is_binary(event.signature)
+    end
+  end
+
   describe "get_event_stats/1" do
     test "returns statistics for events" do
       org = organization_fixture()

--- a/test/authify_web/controllers/api/audit_logs_controller_test.exs
+++ b/test/authify_web/controllers/api/audit_logs_controller_test.exs
@@ -293,4 +293,79 @@ defmodule AuthifyWeb.API.AuditLogsControllerTest do
              } = json_response(conn, 403)
     end
   end
+
+  describe "audit log signature in API responses" do
+    setup %{conn: conn} do
+      org = organization_fixture()
+
+      Authify.Configurations.set_organization_setting(org, :sign_audit_logs, true)
+
+      {:ok, signed_event} =
+        Authify.AuditLog.log_event(:login_success, %{
+          organization_id: org.id,
+          actor_type: "user",
+          actor_id: 1,
+          outcome: "success"
+        })
+
+      Authify.Configurations.set_organization_setting(org, :sign_audit_logs, false)
+
+      {:ok, unsigned_event} =
+        Authify.AuditLog.log_event(:login_failure, %{
+          organization_id: org.id,
+          actor_type: "user",
+          actor_id: 1,
+          outcome: "failure"
+        })
+
+      conn =
+        conn
+        |> put_req_header("accept", "application/vnd.authify.v1+json")
+        |> put_req_header("content-type", "application/vnd.authify.v1+json")
+        |> assign(:current_organization, org)
+        |> assign(:api_authenticated, true)
+        |> assign(:current_scopes, ["audit_logs:read"])
+
+      %{conn: conn, org: org, signed_event: signed_event, unsigned_event: unsigned_event}
+    end
+
+    test "show includes signature and signing_certificate_id for signed event",
+         %{conn: conn, org: org, signed_event: signed_event} do
+      conn = get(conn, ~p"/#{org.slug}/api/audit-logs/#{signed_event.id}")
+      data = json_response(conn, 200)["data"]
+
+      assert data["attributes"]["signature"] != nil
+      assert data["attributes"]["signing_certificate_id"] != nil
+    end
+
+    test "show includes signing_certificate link for signed event",
+         %{conn: conn, org: org, signed_event: signed_event} do
+      conn = get(conn, ~p"/#{org.slug}/api/audit-logs/#{signed_event.id}")
+      data = json_response(conn, 200)["data"]
+      cert_id = signed_event.signing_certificate_id
+
+      assert data["links"]["signing_certificate"] ==
+               "/#{org.slug}/api/certificates/#{cert_id}/download/certificate"
+    end
+
+    test "show returns null signature fields and no signing_certificate link for unsigned event",
+         %{conn: conn, org: org, unsigned_event: unsigned_event} do
+      conn = get(conn, ~p"/#{org.slug}/api/audit-logs/#{unsigned_event.id}")
+      data = json_response(conn, 200)["data"]
+
+      assert data["attributes"]["signature"] == nil
+      assert data["attributes"]["signing_certificate_id"] == nil
+      refute Map.has_key?(data["links"], "signing_certificate")
+    end
+
+    test "index includes signing_certificate link for signed events",
+         %{conn: conn, org: org, signed_event: signed_event} do
+      conn = get(conn, ~p"/#{org.slug}/api/audit-logs")
+      items = json_response(conn, 200)["data"]
+
+      signed = Enum.find(items, &(&1["id"] == to_string(signed_event.id)))
+      assert signed["attributes"]["signature"] != nil
+      assert signed["links"]["signing_certificate"] != nil
+    end
+  end
 end

--- a/test/authify_web/controllers/api/certificates_controller_test.exs
+++ b/test/authify_web/controllers/api/certificates_controller_test.exs
@@ -2,6 +2,7 @@ defmodule AuthifyWeb.API.CertificatesControllerTest do
   use AuthifyWeb.ConnCase, async: true
 
   import Authify.AccountsFixtures
+  alias Authify.Accounts
   alias Authify.AuditLog
 
   setup %{conn: conn} do
@@ -490,6 +491,48 @@ defmodule AuthifyWeb.API.CertificatesControllerTest do
                  "type" => "resource_not_found"
                }
              } = json_response(conn, 404)
+    end
+  end
+
+  describe "DELETE /certificates/:id (soft-delete)" do
+    test "marks certificate as deleted but does not remove it", %{conn: conn, organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+
+      conn = delete(conn, ~p"/#{org.slug}/api/certificates/#{cert.id}")
+      assert response(conn, 204)
+
+      # Row still in DB with deleted_at set
+      raw = Authify.Repo.get(Authify.Accounts.Certificate, cert.id)
+      assert raw.deleted_at != nil
+    end
+
+    test "returns 404 when certificate already soft-deleted", %{conn: conn, organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      conn = delete(conn, ~p"/#{org.slug}/api/certificates/#{cert.id}")
+      assert json_response(conn, 404)["error"]["type"] == "resource_not_found"
+    end
+  end
+
+  describe "GET /certificates/:id/download/certificate for soft-deleted" do
+    test "returns PEM for a soft-deleted certificate", %{conn: conn, organization: org} do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      conn = get(conn, ~p"/#{org.slug}/api/certificates/#{cert.id}/download/certificate")
+      assert response(conn, 200) =~ "BEGIN CERTIFICATE"
+    end
+
+    test "returns 404 for private_key download of soft-deleted certificate", %{
+      conn: conn,
+      organization: org
+    } do
+      {:ok, cert} = Accounts.generate_certificate(org, %{"usage" => "saml_signing"})
+      {:ok, _} = Accounts.delete_certificate(cert)
+
+      conn = get(conn, ~p"/#{org.slug}/api/certificates/#{cert.id}/download/private_key")
+      assert json_response(conn, 404)["error"]["type"] == "resource_not_found"
     end
   end
 

--- a/test/authify_web/controllers/api/organization_controller_test.exs
+++ b/test/authify_web/controllers/api/organization_controller_test.exs
@@ -126,6 +126,31 @@ defmodule AuthifyWeb.API.OrganizationControllerTest do
       assert event.metadata["schema"] == "organization"
       assert event.metadata["source"] == "api"
     end
+
+    test "accepts sign_audit_logs boolean setting", %{conn: conn, organization: organization} do
+      conn =
+        put(conn, "/#{organization.slug}/api/organization/configuration", %{
+          "settings" => %{
+            "sign_audit_logs" => "true"
+          }
+        })
+
+      assert %{"data" => %{"type" => "configuration"}} = json_response(conn, 200)
+
+      assert Authify.Configurations.get_organization_setting(organization, :sign_audit_logs) ==
+               true
+    end
+
+    test "rejects sign_audit_logs non-boolean value", %{conn: conn, organization: organization} do
+      conn =
+        put(conn, "/#{organization.slug}/api/organization/configuration", %{
+          "settings" => %{
+            "sign_audit_logs" => "not-a-bool"
+          }
+        })
+
+      assert %{"error" => %{"type" => "validation_error"}} = json_response(conn, 422)
+    end
   end
 
   # Note: PUT /api/organization and /api/organization/settings endpoints have been

--- a/test/authify_web/controllers/configuration_controller_test.exs
+++ b/test/authify_web/controllers/configuration_controller_test.exs
@@ -595,5 +595,41 @@ defmodule AuthifyWeb.ConfigurationControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                "Error updating some settings"
     end
+
+    test "accepts sign_audit_logs boolean setting", %{conn: conn} do
+      organization = organization_fixture()
+      admin = user_fixture(%{organization: organization, role: "admin"})
+
+      conn =
+        conn
+        |> log_in_user(admin)
+        |> patch(~p"/#{organization.slug}/settings/configuration", %{
+          "settings" => %{
+            "sign_audit_logs" => "true"
+          }
+        })
+
+      assert redirected_to(conn) == ~p"/#{organization.slug}/settings/configuration"
+
+      assert Authify.Configurations.get_organization_setting(organization, :sign_audit_logs) ==
+               true
+    end
+
+    test "rejects sign_audit_logs non-boolean", %{conn: conn} do
+      organization = organization_fixture()
+      admin = user_fixture(%{organization: organization, role: "admin"})
+
+      conn =
+        conn
+        |> log_in_user(admin)
+        |> patch(~p"/#{organization.slug}/settings/configuration", %{
+          "settings" => %{
+            "sign_audit_logs" => "not-a-bool"
+          }
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "Error updating some settings"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- **Opt-in signing**: organizations enable `sign_audit_logs` via settings; each new audit event is signed with RSA-SHA256 using the org's `audit_signing` certificate
- **Soft-deleted certificates**: certificates are never hard-deleted so the public PEM remains retrievable for offline verification indefinitely
- **ETS key cache**: `AuditLog.KeyCache` caches decoded private keys per org to avoid DB + decrypt overhead on every signed event
- **API exposure**: `signature` and `signing_certificate_id` attributes in audit log responses, plus a `signing_certificate` link to the PEM download endpoint
- **UI**: Sign Audit Logs toggle in org settings; `bi-shield-check` icon in the audit log index for signed events; a Cryptographic Signature card on the event detail page (with copyable signature, PEM download link, and an "Unsigned" badge for pre-signing events)

## New modules

| Module | Purpose |
|---|---|
| `Authify.AuditLog.Signer` | Canonical payload construction, RSA-SHA256 sign/verify |
| `Authify.AuditLog.KeyCache` | ETS-backed GenServer caching decoded private keys per org |

## Key design decisions

- Canonical payload: fixed field set in alphabetical key order, `nil` → JSON `null` (never omitted), `id` excluded since it's assigned post-insert
- `on_delete: :nothing` (MySQL RESTRICT) on `audit_events.signing_certificate_id` prevents hard-deleting a cert still referenced by an event
- Signing failures degrade silently — the event is still recorded, just unsigned

## Test plan

- [x] `AuditLog.Signer` unit tests: canonical payload determinism, null fields, sign/verify round-trip, tamper detection, unsigned detection
- [x] `AuditLog.KeyCache` unit tests: miss, round-trip, invalidation
- [x] `AuditLog` context tests: no-sign default, sign when enabled, async signing, verification
- [x] Certificate soft-delete tests: `delete_certificate/1` sets `deleted_at`; soft-deleted certs excluded from list/show; public PEM still downloadable; private key returns 404
- [x] Certificates API tests: soft-delete via DELETE endpoint; PEM download for soft-deleted cert
- [x] Audit logs API tests: signature + `signing_certificate` link for signed events; null fields + no link for unsigned
- [x] Configuration tests (API + web): `sign_audit_logs` boolean accepted; non-boolean returns 422/error

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)