### PR TITLE
refactor: adopt FilterSort consistently across accounts, o_auth, and saml

### DIFF
--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -5,7 +5,6 @@ defmodule Authify.Accounts do
 
   import Ecto.Query, warn: false
   import Ecto.Changeset, only: [get_change: 2, get_field: 2]
-  alias Authify.Repo
 
   alias Authify.Accounts.{
     Certificate,
@@ -18,6 +17,9 @@ defmodule Authify.Accounts do
     User,
     UserEmail
   }
+
+  alias Authify.FilterSort
+  alias Authify.Repo
 
   alias Authify.SCIM.{AttributeMapper, FilterParser, QueryFilter}
 
@@ -58,50 +60,17 @@ defmodule Authify.Accounts do
     maybe_filter_organization_by_status(query, opts[:status])
   end
 
-  defp maybe_filter_organization_by_status(query, nil),
-    do: where(query, [o], o.active == true)
+  defp maybe_filter_organization_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :active, status)
 
-  defp maybe_filter_organization_by_status(query, ""),
-    do: where(query, [o], o.active == true)
+  defp apply_organization_search(query, search),
+    do: FilterSort.apply_multi_text_filter(query, [:name, :slug], search)
 
-  defp maybe_filter_organization_by_status(query, "all"), do: query
-  defp maybe_filter_organization_by_status(query, true), do: where(query, [o], o.active == true)
+  @organization_sort_fields [:name, :slug, :inserted_at, :updated_at]
 
-  defp maybe_filter_organization_by_status(query, "true"),
-    do: where(query, [o], o.active == true)
-
-  defp maybe_filter_organization_by_status(query, false),
-    do: where(query, [o], o.active == false)
-
-  defp maybe_filter_organization_by_status(query, "false"),
-    do: where(query, [o], o.active == false)
-
-  defp maybe_filter_organization_by_status(query, _), do: where(query, [o], o.active == true)
-
-  defp apply_organization_search(query, nil), do: query
-  defp apply_organization_search(query, ""), do: query
-
-  defp apply_organization_search(query, search_term) when is_binary(search_term) do
-    search_pattern = "%#{search_term}%"
-
-    where(
-      query,
-      [o],
-      like(o.name, ^search_pattern) or like(o.slug, ^search_pattern)
-    )
-  end
-
-  defp apply_organization_sorting(query, nil, _), do: order_by(query, [o], asc: o.name)
-  defp apply_organization_sorting(query, "", _), do: order_by(query, [o], asc: o.name)
-
-  defp apply_organization_sorting(query, sort_field, order)
-       when sort_field in [:name, :slug, :inserted_at, :updated_at] do
-    order_atom = if order == :desc or order == "desc", do: :desc, else: :asc
-    order_by(query, [o], ^[{order_atom, sort_field}])
-  end
-
-  defp apply_organization_sorting(query, _sort_field, _order),
-    do: order_by(query, [o], asc: o.name)
+  defp apply_organization_sorting(query, sort, order),
+    do:
+      FilterSort.apply_sort(query, sort, order, @organization_sort_fields, default: [asc: :name])
 
   @doc """
   Gets a single organization.
@@ -209,14 +178,8 @@ defmodule Authify.Accounts do
 
   defp maybe_filter_by_role(query, _), do: query
 
-  defp maybe_filter_by_status(query, nil), do: where(query, [u], u.active == true)
-  defp maybe_filter_by_status(query, ""), do: where(query, [u], u.active == true)
-  defp maybe_filter_by_status(query, "all"), do: query
-  defp maybe_filter_by_status(query, true), do: where(query, [u], u.active == true)
-  defp maybe_filter_by_status(query, "true"), do: where(query, [u], u.active == true)
-  defp maybe_filter_by_status(query, false), do: where(query, [u], u.active == false)
-  defp maybe_filter_by_status(query, "false"), do: where(query, [u], u.active == false)
-  defp maybe_filter_by_status(query, _), do: where(query, [u], u.active == true)
+  defp maybe_filter_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :active, status)
 
   defp apply_user_search(query, nil), do: query
   defp apply_user_search(query, ""), do: query
@@ -2104,49 +2067,19 @@ defmodule Authify.Accounts do
     maybe_filter_org_stats_by_status(query, opts[:status])
   end
 
-  defp maybe_filter_org_stats_by_status(query, nil),
-    do: where(query, [o], o.active == true)
+  defp maybe_filter_org_stats_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :active, status)
 
-  defp maybe_filter_org_stats_by_status(query, ""),
-    do: where(query, [o], o.active == true)
+  defp apply_org_stats_search(query, search),
+    do: FilterSort.apply_multi_text_filter(query, [:name, :slug], search)
 
-  defp maybe_filter_org_stats_by_status(query, "all"), do: query
-  defp maybe_filter_org_stats_by_status(query, true), do: where(query, [o], o.active == true)
+  @org_stats_sort_fields [:name, :slug, :inserted_at, :updated_at]
 
-  defp maybe_filter_org_stats_by_status(query, "true"),
-    do: where(query, [o], o.active == true)
-
-  defp maybe_filter_org_stats_by_status(query, false), do: where(query, [o], o.active == false)
-
-  defp maybe_filter_org_stats_by_status(query, "false"),
-    do: where(query, [o], o.active == false)
-
-  defp maybe_filter_org_stats_by_status(query, _), do: where(query, [o], o.active == true)
-
-  defp apply_org_stats_search(query, nil), do: query
-  defp apply_org_stats_search(query, ""), do: query
-
-  defp apply_org_stats_search(query, search_term) when is_binary(search_term) do
-    search_pattern = "%#{search_term}%"
-
-    where(
-      query,
-      [o],
-      like(o.name, ^search_pattern) or like(o.slug, ^search_pattern)
-    )
-  end
-
-  defp apply_org_stats_sorting(query, nil, _), do: order_by(query, [o], desc: o.inserted_at)
-  defp apply_org_stats_sorting(query, "", _), do: order_by(query, [o], desc: o.inserted_at)
-
-  defp apply_org_stats_sorting(query, sort_field, order)
-       when sort_field in [:name, :slug, :inserted_at, :updated_at] do
-    order_atom = if order == :desc or order == "desc", do: :desc, else: :asc
-    order_by(query, [o], ^[{order_atom, sort_field}])
-  end
-
-  defp apply_org_stats_sorting(query, _sort_field, _order),
-    do: order_by(query, [o], desc: o.inserted_at)
+  defp apply_org_stats_sorting(query, sort, order),
+    do:
+      FilterSort.apply_sort(query, sort, order, @org_stats_sort_fields,
+        default: [desc: :inserted_at]
+      )
 
   @doc """
   Gets system stats.
@@ -2490,55 +2423,16 @@ defmodule Authify.Accounts do
     maybe_filter_group_by_status(query, opts[:status])
   end
 
-  defp maybe_filter_group_by_status(query, nil),
-    do: query
+  defp maybe_filter_group_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :is_active, status, default_all: true)
 
-  defp maybe_filter_group_by_status(query, ""),
-    do: query
+  defp apply_group_search(query, search),
+    do: FilterSort.apply_multi_text_filter(query, [:name, :description], search)
 
-  defp maybe_filter_group_by_status(query, "all"), do: query
+  @group_sort_fields [:name, :description, :is_active, :inserted_at, :updated_at]
 
-  defp maybe_filter_group_by_status(query, true),
-    do: where(query, [g], g.is_active == true)
-
-  defp maybe_filter_group_by_status(query, "true"),
-    do: where(query, [g], g.is_active == true)
-
-  defp maybe_filter_group_by_status(query, false),
-    do: where(query, [g], g.is_active == false)
-
-  defp maybe_filter_group_by_status(query, "false"),
-    do: where(query, [g], g.is_active == false)
-
-  defp maybe_filter_group_by_status(query, _),
-    do: query
-
-  defp apply_group_search(query, nil), do: query
-  defp apply_group_search(query, ""), do: query
-
-  defp apply_group_search(query, search_term) when is_binary(search_term) do
-    search_pattern = "%#{search_term}%"
-
-    where(
-      query,
-      [g],
-      like(g.name, ^search_pattern) or like(g.description, ^search_pattern)
-    )
-  end
-
-  defp apply_group_sorting(query, nil, _),
-    do: order_by(query, [g], asc: g.name)
-
-  defp apply_group_sorting(query, "", _), do: order_by(query, [g], asc: g.name)
-
-  defp apply_group_sorting(query, sort_field, order)
-       when sort_field in [:name, :description, :is_active, :inserted_at, :updated_at] do
-    order_atom = if order == :asc or order == "asc", do: :asc, else: :desc
-    order_by(query, [g], ^[{order_atom, sort_field}])
-  end
-
-  defp apply_group_sorting(query, _sort_field, _order),
-    do: order_by(query, [g], asc: g.name)
+  defp apply_group_sorting(query, sort, order),
+    do: FilterSort.apply_sort(query, sort, order, @group_sort_fields, default: [asc: :name])
 
   @doc """
   Gets a single group by ID within an organization.

--- a/lib/authify/filter_sort.ex
+++ b/lib/authify/filter_sort.ex
@@ -129,6 +129,43 @@ defmodule Authify.FilterSort do
   def apply_boolean_filter(query, _field, _value), do: query
 
   @doc """
+  Applies a common active/inactive status filter to a query.
+
+  Handles these input values consistently:
+    * `nil`, `""`, fallback → filter where field == true (active-only)
+    * `"all"` → no filter (return query unchanged)
+    * `true`, `"true"` → filter where field == true
+    * `false`, `"false"` → filter where field == false
+
+  ## Options
+    * `:default_all` — when `true`, the default behavior returns the query unchanged
+      instead of filtering for active-only (useful for resources that default to showing all).
+
+  ## Examples
+
+     iex> apply_status_filter(User, :active, nil)
+      #Ecto.Query<...> where field == true
+
+     iex> apply_status_filter(Group, :is_active, nil, default_all: true)
+      #Ecto.Query<...> (unchanged)
+  """
+  def apply_status_filter(query, field, value \\ nil, opts \\ []) do
+    default_all = Keyword.get(opts, :default_all, false)
+
+    case value do
+      nil when default_all -> query
+      "" when default_all -> query
+      "all" -> query
+      true -> where(query, [q], field(q, ^field) == true)
+      "true" -> where(query, [q], field(q, ^field) == true)
+      false -> where(query, [q], field(q, ^field) == false)
+      "false" -> where(query, [q], field(q, ^field) == false)
+      _ when default_all -> query
+      _ -> where(query, [q], field(q, ^field) == true)
+    end
+  end
+
+  @doc """
   Parses filter parameters from Phoenix params.
 
   Expects filters in the format: `filter[field_name]=value`
@@ -161,6 +198,8 @@ defmodule Authify.FilterSort do
   defp normalize_field(field) when is_atom(field), do: field
   defp normalize_field(_), do: nil
 
+  defp normalize_order(:desc), do: :desc
+  defp normalize_order(:asc), do: :asc
   defp normalize_order("desc"), do: :desc
   defp normalize_order("DESC"), do: :desc
   defp normalize_order(_), do: :asc

--- a/lib/authify/o_auth.ex
+++ b/lib/authify/o_auth.ex
@@ -4,10 +4,10 @@ defmodule Authify.OAuth do
   """
 
   import Ecto.Query, warn: false
-  alias Authify.Repo
-
   alias Authify.Accounts.{Organization, User}
+  alias Authify.FilterSort
   alias Authify.OAuth.{AccessToken, Application, AuthorizationCode, RefreshToken, UserGrant}
+  alias Authify.Repo
 
   @doc """
   Returns the list of applications for an organization.
@@ -63,41 +63,19 @@ defmodule Authify.OAuth do
     maybe_filter_application_by_status(query, opts[:status])
   end
 
-  defp maybe_filter_application_by_status(query, nil), do: where(query, [a], a.is_active == true)
-  defp maybe_filter_application_by_status(query, ""), do: where(query, [a], a.is_active == true)
-  defp maybe_filter_application_by_status(query, "all"), do: query
-  defp maybe_filter_application_by_status(query, true), do: where(query, [a], a.is_active == true)
+  defp maybe_filter_application_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :is_active, status)
 
-  defp maybe_filter_application_by_status(query, "true"),
-    do: where(query, [a], a.is_active == true)
+  defp apply_application_search(query, search),
+    do: FilterSort.apply_text_filter(query, :name, search)
 
-  defp maybe_filter_application_by_status(query, false),
-    do: where(query, [a], a.is_active == false)
+  @application_sort_fields [:name, :client_id, :inserted_at, :updated_at]
 
-  defp maybe_filter_application_by_status(query, "false"),
-    do: where(query, [a], a.is_active == false)
-
-  defp maybe_filter_application_by_status(query, _), do: where(query, [a], a.is_active == true)
-
-  defp apply_application_search(query, nil), do: query
-  defp apply_application_search(query, ""), do: query
-
-  defp apply_application_search(query, search_term) when is_binary(search_term) do
-    search_pattern = "%#{search_term}%"
-    where(query, [a], like(a.name, ^search_pattern))
-  end
-
-  defp apply_application_sorting(query, nil, _), do: order_by(query, [a], desc: a.inserted_at)
-  defp apply_application_sorting(query, "", _), do: order_by(query, [a], desc: a.inserted_at)
-
-  defp apply_application_sorting(query, sort_field, order)
-       when sort_field in [:name, :client_id, :inserted_at, :updated_at] do
-    order_atom = if order == :asc or order == "asc", do: :asc, else: :desc
-    order_by(query, [a], ^[{order_atom, sort_field}])
-  end
-
-  defp apply_application_sorting(query, _sort_field, _order),
-    do: order_by(query, [a], desc: a.inserted_at)
+  defp apply_application_sorting(query, sort, order),
+    do:
+      FilterSort.apply_sort(query, sort, order, @application_sort_fields,
+        default: [desc: :inserted_at]
+      )
 
   @doc """
   Returns the list of Management API applications for an organization.

--- a/lib/authify/saml.ex
+++ b/lib/authify/saml.ex
@@ -50,28 +50,8 @@ defmodule Authify.SAML do
     maybe_filter_saml_provider_by_status(query, opts[:status])
   end
 
-  defp maybe_filter_saml_provider_by_status(query, nil),
-    do: where(query, [sp], sp.is_active == true)
-
-  defp maybe_filter_saml_provider_by_status(query, ""),
-    do: where(query, [sp], sp.is_active == true)
-
-  defp maybe_filter_saml_provider_by_status(query, "all"), do: query
-
-  defp maybe_filter_saml_provider_by_status(query, true),
-    do: where(query, [sp], sp.is_active == true)
-
-  defp maybe_filter_saml_provider_by_status(query, "true"),
-    do: where(query, [sp], sp.is_active == true)
-
-  defp maybe_filter_saml_provider_by_status(query, false),
-    do: where(query, [sp], sp.is_active == false)
-
-  defp maybe_filter_saml_provider_by_status(query, "false"),
-    do: where(query, [sp], sp.is_active == false)
-
-  defp maybe_filter_saml_provider_by_status(query, _),
-    do: where(query, [sp], sp.is_active == true)
+  defp maybe_filter_saml_provider_by_status(query, status),
+    do: FilterSort.apply_status_filter(query, :is_active, status)
 
   @doc """
   Returns a paginated list of service providers for an organization.


### PR DESCRIPTION
## Summary

Adopts the `Authify.FilterSort` module consistently across `accounts.ex`, `o_auth.ex`, and `saml.ex`, eliminating 6× duplicated status filtering and 5× inconsistent sort normalization.

### Changes

- **`FilterSort.apply_status_filter/3`** — New function handling the common active/inactive status filter pattern (nil/""/all/true/false/"true"/"false"), with `:default_all` option for resources that default to showing all
- **`accounts.ex`** — Replaced `maybe_filter_organization_by_status`, `maybe_filter_by_status` (users), `maybe_filter_org_stats_by_status`, `maybe_filter_group_by_status` with `apply_status_filter/3`; replaced inline sort/search with `FilterSort.apply_sort/5` and `apply_multi_text_filter/3`
- **`o_auth.ex`** — Replaced `maybe_filter_application_by_status` with `apply_status_filter/3`; replaced inline sort/search
- **`saml.ex`** — Replaced `maybe_filter_saml_provider_by_status` with `apply_status_filter/3` (search/sort already used FilterSort)

### Preserved behaviors

- User search/sort left as-is (uses joins + fragments that FilterSort cannot express)
- Per-resource defaults preserved (orgs/users/apps/saml default to active-only; groups default to showing all)
- Default sort fields and directions preserved per resource

### Normalized behaviors (intentional fixes)

- Sort direction normalization now consistent via `FilterSort.normalize_order/1` (groups and applications previously used opposite default direction logic)

### Additional fix

- Extended `normalize_order/1` to handle atom inputs (`:asc`, `:desc`) in addition to strings, since callers pass atoms directly through keyword list options