### PR TITLE
refactor: extract duplicated email CSS/layout boilerplate

### DIFF
--- a/lib/authify/email.ex
+++ b/lib/authify/email.ex
@@ -38,102 +38,38 @@ defmodule Authify.Email do
   defp invitation_html_body(invitation, invited_by, organization, accept_url) do
     invited_by_email = User.get_primary_email_value(invited_by)
 
+    content = """
+    <h2>You've been invited to join #{organization.name}</h2>
+
+    <p>Hello,</p>
+
+    <p>
+      <strong>#{invited_by.first_name} #{invited_by.last_name}</strong> (#{invited_by_email})
+      has invited you to join <strong>#{organization.name}</strong> on Authify as a
+      <strong>#{String.capitalize(invitation.role)}</strong>.
+    </p>
+
+    <p>Click the button below to accept the invitation and create your account:</p>
+
+    <p style="text-align: center;">
+      <a href="#{accept_url}" class="button">Accept Invitation</a>
+    </p>
+
+    <p style="font-size: 14px; color: #6c757d;">
+      Or copy and paste this link into your browser:<br>
+      <a href="#{accept_url}">#{accept_url}</a>
+    </p>
+
+    <div class="notice">
+      <strong>⏰ This invitation expires on #{format_datetime(invitation.expires_at)}</strong>
+    </div>
+
+    <p>
+      If you weren't expecting this invitation, you can safely ignore this email.
+    </p>
     """
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-          line-height: 1.6;
-          color: #333;
-          max-width: 600px;
-          margin: 0 auto;
-          padding: 20px;
-        }
-        .header {
-          text-align: center;
-          padding: 20px 0;
-          border-bottom: 2px solid #0d6efd;
-        }
-        .logo {
-          width: 64px;
-          height: 64px;
-        }
-        .content {
-          padding: 30px 0;
-        }
-        .button {
-          display: inline-block;
-          padding: 12px 24px;
-          background-color: #0d6efd;
-          color: #ffffff;
-          text-decoration: none;
-          border-radius: 5px;
-          margin: 20px 0;
-        }
-        .footer {
-          margin-top: 40px;
-          padding-top: 20px;
-          border-top: 1px solid #dee2e6;
-          font-size: 14px;
-          color: #6c757d;
-        }
-        .expiry-notice {
-          background-color: #fff3cd;
-          border-left: 4px solid #ffc107;
-          padding: 12px;
-          margin: 20px 0;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="header">
-        <h1>Authify</h1>
-      </div>
 
-      <div class="content">
-        <h2>You've been invited to join #{organization.name}</h2>
-
-        <p>Hello,</p>
-
-        <p>
-          <strong>#{invited_by.first_name} #{invited_by.last_name}</strong> (#{invited_by_email})
-          has invited you to join <strong>#{organization.name}</strong> on Authify as a
-          <strong>#{String.capitalize(invitation.role)}</strong>.
-        </p>
-
-        <p>Click the button below to accept the invitation and create your account:</p>
-
-        <p style="text-align: center;">
-          <a href="#{accept_url}" class="button">Accept Invitation</a>
-        </p>
-
-        <p style="font-size: 14px; color: #6c757d;">
-          Or copy and paste this link into your browser:<br>
-          <a href="#{accept_url}">#{accept_url}</a>
-        </p>
-
-        <div class="expiry-notice">
-          <strong>⏰ This invitation expires on #{format_datetime(invitation.expires_at)}</strong>
-        </div>
-
-        <p>
-          If you weren't expecting this invitation, you can safely ignore this email.
-        </p>
-      </div>
-
-      <div class="footer">
-        <p>
-          This email was sent by #{organization.name} via Authify.<br>
-          Questions? Contact <a href="mailto:#{invited_by_email}">#{invited_by_email}</a>
-        </p>
-      </div>
-    </body>
-    </html>
-    """
+    email_layout(content, email_footer(organization, invited_by_email))
   end
 
   defp invitation_text_body(invitation, invited_by, organization, accept_url) do
@@ -180,7 +116,7 @@ defmodule Authify.Email do
     organization = invitation.organization
 
     # In development, send to local mailbox even without SMTP
-    if dev_mode?() do
+    if dev_or_test_mode?() do
       invitation
       |> invitation_email(accept_url)
       |> Mailer.deliver()
@@ -225,98 +161,38 @@ defmodule Authify.Email do
   end
 
   defp password_reset_html_body(user, organization, reset_url) do
+    content = """
+    <h2>Password Reset Request</h2>
+
+    <p>Hello #{user.first_name},</p>
+
+    <p>
+      We received a request to reset your password for your account at
+      <strong>#{organization.name}</strong>.
+    </p>
+
+    <p>Click the button below to reset your password:</p>
+
+    <p style="text-align: center;">
+      <a href="#{reset_url}" class="button">Reset Password</a>
+    </p>
+
+    <p style="font-size: 14px; color: #6c757d;">
+      Or copy and paste this link into your browser:<br>
+      <a href="#{reset_url}">#{reset_url}</a>
+    </p>
+
+    <div class="notice">
+      <strong>⏰ This link expires in 24 hours</strong>
+    </div>
+
+    <div class="notice">
+      <strong>🔒 Security Notice:</strong> If you didn't request this password reset,
+      please ignore this email. Your password will not be changed.
+    </div>
     """
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-          line-height: 1.6;
-          color: #333;
-          max-width: 600px;
-          margin: 0 auto;
-          padding: 20px;
-        }
-        .header {
-          text-align: center;
-          padding: 20px 0;
-          border-bottom: 2px solid #0d6efd;
-        }
-        .content {
-          padding: 30px 0;
-        }
-        .button {
-          display: inline-block;
-          padding: 12px 24px;
-          background-color: #0d6efd;
-          color: #ffffff;
-          text-decoration: none;
-          border-radius: 5px;
-          margin: 20px 0;
-        }
-        .footer {
-          margin-top: 40px;
-          padding-top: 20px;
-          border-top: 1px solid #dee2e6;
-          font-size: 14px;
-          color: #6c757d;
-        }
-        .security-notice {
-          background-color: #fff3cd;
-          border-left: 4px solid #ffc107;
-          padding: 12px;
-          margin: 20px 0;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="header">
-        <h1>Authify</h1>
-      </div>
 
-      <div class="content">
-        <h2>Password Reset Request</h2>
-
-        <p>Hello #{user.first_name},</p>
-
-        <p>
-          We received a request to reset your password for your account at
-          <strong>#{organization.name}</strong>.
-        </p>
-
-        <p>Click the button below to reset your password:</p>
-
-        <p style="text-align: center;">
-          <a href="#{reset_url}" class="button">Reset Password</a>
-        </p>
-
-        <p style="font-size: 14px; color: #6c757d;">
-          Or copy and paste this link into your browser:<br>
-          <a href="#{reset_url}">#{reset_url}</a>
-        </p>
-
-        <div class="security-notice">
-          <strong>⏰ This link expires in 24 hours</strong>
-        </div>
-
-        <div class="security-notice">
-          <strong>🔒 Security Notice:</strong> If you didn't request this password reset,
-          please ignore this email. Your password will not be changed.
-        </div>
-      </div>
-
-      <div class="footer">
-        <p>
-          This email was sent by #{organization.name} via Authify.<br>
-          If you have questions, please contact your organization administrator.
-        </p>
-      </div>
-    </body>
-    </html>
-    """
+    email_layout(content, email_footer(organization))
   end
 
   defp password_reset_text_body(user, organization, reset_url) do
@@ -361,7 +237,7 @@ defmodule Authify.Email do
     organization = user.organization
 
     # In development, send to local mailbox even without SMTP
-    if dev_mode?() do
+    if dev_or_test_mode?() do
       user
       |> password_reset_email(reset_url)
       |> Mailer.deliver()
@@ -406,97 +282,37 @@ defmodule Authify.Email do
   end
 
   defp email_verification_html_body(user, organization, verification_url) do
+    content = """
+    <h2>Verify Your Email Address</h2>
+
+    <p>Hello #{user.first_name},</p>
+
+    <p>
+      Welcome to <strong>#{organization.name}</strong>! Please verify your email address
+      to activate your account.
+    </p>
+
+    <p>Click the button below to verify your email:</p>
+
+    <p style="text-align: center;">
+      <a href="#{verification_url}" class="button">Verify Email</a>
+    </p>
+
+    <p style="font-size: 14px; color: #6c757d;">
+      Or copy and paste this link into your browser:<br>
+      <a href="#{verification_url}">#{verification_url}</a>
+    </p>
+
+    <div class="notice">
+      <strong>⏰ This verification link expires in 24 hours</strong>
+    </div>
+
+    <p>
+      If you didn't create an account, you can safely ignore this email.
+    </p>
     """
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <style>
-        body {
-          font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-          line-height: 1.6;
-          color: #333;
-          max-width: 600px;
-          margin: 0 auto;
-          padding: 20px;
-        }
-        .header {
-          text-align: center;
-          padding: 20px 0;
-          border-bottom: 2px solid #0d6efd;
-        }
-        .content {
-          padding: 30px 0;
-        }
-        .button {
-          display: inline-block;
-          padding: 12px 24px;
-          background-color: #0d6efd;
-          color: #ffffff;
-          text-decoration: none;
-          border-radius: 5px;
-          margin: 20px 0;
-        }
-        .footer {
-          margin-top: 40px;
-          padding-top: 20px;
-          border-top: 1px solid #dee2e6;
-          font-size: 14px;
-          color: #6c757d;
-        }
-        .expiry-notice {
-          background-color: #fff3cd;
-          border-left: 4px solid #ffc107;
-          padding: 12px;
-          margin: 20px 0;
-        }
-      </style>
-    </head>
-    <body>
-      <div class="header">
-        <h1>Authify</h1>
-      </div>
 
-      <div class="content">
-        <h2>Verify Your Email Address</h2>
-
-        <p>Hello #{user.first_name},</p>
-
-        <p>
-          Welcome to <strong>#{organization.name}</strong>! Please verify your email address
-          to activate your account.
-        </p>
-
-        <p>Click the button below to verify your email:</p>
-
-        <p style="text-align: center;">
-          <a href="#{verification_url}" class="button">Verify Email</a>
-        </p>
-
-        <p style="font-size: 14px; color: #6c757d;">
-          Or copy and paste this link into your browser:<br>
-          <a href="#{verification_url}">#{verification_url}</a>
-        </p>
-
-        <div class="expiry-notice">
-          <strong>⏰ This verification link expires in 24 hours</strong>
-        </div>
-
-        <p>
-          If you didn't create an account, you can safely ignore this email.
-        </p>
-      </div>
-
-      <div class="footer">
-        <p>
-          This email was sent by #{organization.name} via Authify.<br>
-          If you have questions, please contact your organization administrator.
-        </p>
-      </div>
-    </body>
-    </html>
-    """
+    email_layout(content, email_footer(organization))
   end
 
   defp email_verification_text_body(user, organization, verification_url) do
@@ -560,14 +376,109 @@ defmodule Authify.Email do
     end
   end
 
-  # Check if running in development or test mode
-  defp dev_or_test_mode? do
-    Application.get_env(:authify, :env) in [:dev, :test]
+  # ── Shared email layout helpers ──────────────────────────────────────
+
+  defp shared_css do
+    """
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+    .header {
+      text-align: center;
+      padding: 20px 0;
+      border-bottom: 2px solid #0d6efd;
+    }
+    .content {
+      padding: 30px 0;
+    }
+    .button {
+      display: inline-block;
+      padding: 12px 24px;
+      background-color: #0d6efd;
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 5px;
+      margin: 20px 0;
+    }
+    .notice {
+      background-color: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 12px;
+      margin: 20px 0;
+    }
+    .footer {
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #dee2e6;
+      font-size: 14px;
+      color: #6c757d;
+    }
+    """
   end
 
-  # Check if running in development mode
-  defp dev_mode? do
-    Application.get_env(:authify, :env) == :dev
+  defp email_header do
+    """
+    <div class="header">
+      <h1>Authify</h1>
+    </div>
+    """
+  end
+
+  defp email_footer(organization) do
+    """
+    <div class="footer">
+      <p>
+        This email was sent by #{organization.name} via Authify.<br>
+        If you have questions, please contact your organization administrator.
+      </p>
+    </div>
+    """
+  end
+
+  defp email_footer(organization, contact_email) do
+    """
+    <div class="footer">
+      <p>
+        This email was sent by #{organization.name} via Authify.<br>
+        Questions? Contact <a href="mailto:#{contact_email}">#{contact_email}</a>
+      </p>
+    </div>
+    """
+  end
+
+  defp email_layout(content, footer) do
+    """
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <style>
+    #{shared_css()}
+      </style>
+    </head>
+    <body>
+    #{email_header()}
+
+      <div class="content">
+    #{content}
+      </div>
+
+    #{footer}
+    </body>
+    </html>
+    """
+  end
+
+  # ── Internal helpers ─────────────────────────────────────────────────
+
+  defp dev_or_test_mode? do
+    Application.get_env(:authify, :env) in [:dev, :test]
   end
 
   # Get from address from organization settings, or use dev/test default

--- a/test/authify/email_test.exs
+++ b/test/authify/email_test.exs
@@ -1,0 +1,182 @@
+defmodule Authify.EmailTest do
+  use Authify.DataCase, async: true
+
+  import Swoosh.TestAssertions
+  import Authify.AccountsFixtures
+
+  alias Authify.Email
+
+  defp create_invitation(organization, inviter, attrs \\ %{}) do
+    {:ok, invitation} =
+      attrs
+      |> Enum.into(%{
+        "email" => "invitee@example.com",
+        "role" => "user",
+        "organization_id" => organization.id,
+        "invited_by_id" => inviter.id
+      })
+      |> Authify.Accounts.create_invitation()
+
+    Authify.Repo.preload(invitation, [:organization, invited_by: [:emails]])
+  end
+
+  describe "invitation_email/2" do
+    test "html body contains accept URL, organization name, and role" do
+      organization = organization_fixture()
+      inviter = admin_user_fixture(organization)
+
+      invitation = create_invitation(organization, inviter, %{"role" => "admin"})
+
+      accept_url = "https://example.com/accept/456"
+      email = Email.invitation_email(invitation, accept_url)
+
+      assert email.subject == "You've been invited to join #{organization.name} on Authify"
+      assert email.html_body =~ accept_url
+      assert email.html_body =~ organization.name
+      assert email.html_body =~ "Admin"
+      assert email.html_body =~ "Accept Invitation"
+    end
+
+    test "text body contains key content" do
+      organization = organization_fixture()
+      inviter = admin_user_fixture(organization)
+
+      invitation = create_invitation(organization, inviter)
+
+      accept_url = "https://example.com/accept/789"
+      email = Email.invitation_email(invitation, accept_url)
+
+      assert email.text_body =~ accept_url
+      assert email.text_body =~ organization.name
+      assert email.text_body =~ "User"
+    end
+  end
+
+  describe "password_reset_email/2" do
+    test "html body contains reset URL and security notice" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      reset_url = "https://example.com/reset/def"
+      email = Email.password_reset_email(user, reset_url)
+
+      assert email.subject == "Password Reset Request - #{organization.name}"
+      assert email.html_body =~ reset_url
+      assert email.html_body =~ "Reset Password"
+      assert email.html_body =~ "Security Notice"
+    end
+
+    test "text body contains reset URL and expiry notice" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      reset_url = "https://example.com/reset/ghi"
+      email = Email.password_reset_email(user, reset_url)
+
+      assert email.text_body =~ reset_url
+      assert email.text_body =~ "expires in 24 hours"
+    end
+  end
+
+  describe "email_verification_email/2" do
+    test "html body contains verification URL and button" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      verify_url = "https://example.com/verify/123"
+      email = Email.email_verification_email(user, verify_url)
+
+      assert email.subject == "Please verify your email - #{organization.name}"
+      assert email.html_body =~ verify_url
+      assert email.html_body =~ "Verify Email"
+      assert email.html_body =~ "expires in 24 hours"
+    end
+  end
+
+  describe "send functions" do
+    test "send_invitation_email/2 delivers in test mode" do
+      organization = organization_fixture()
+      inviter = admin_user_fixture(organization)
+
+      invitation = create_invitation(organization, inviter)
+
+      assert {:ok, _} = Email.send_invitation_email(invitation, "https://example.com/accept/1")
+    end
+
+    test "send_email_verification_email/2 delivers in test mode" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      assert {:ok, _} = Email.send_email_verification_email(user, "https://example.com/verify/1")
+    end
+
+    test "send_password_reset_email/2 delivers in test mode" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      assert {:ok, _} = Email.send_password_reset_email(user, "https://example.com/reset/1")
+    end
+  end
+
+  describe "format_datetime/1" do
+    test "formats a datetime as a date string" do
+      organization = organization_fixture()
+      inviter = admin_user_fixture(organization)
+
+      expires_at = DateTime.new!(~D[2026-12-25], ~T[00:00:00], "Etc/UTC")
+
+      invitation = create_invitation(organization, inviter, %{"expires_at" => expires_at})
+
+      email = Email.invitation_email(invitation, "https://example.com/accept/1")
+
+      assert email.html_body =~ "2026-12-25"
+      assert email.text_body =~ "2026-12-25"
+    end
+  end
+
+  describe "email footer" do
+    test "invitation footer includes contact email link" do
+      organization = organization_fixture()
+      inviter = admin_user_fixture(organization)
+
+      invitation = create_invitation(organization, inviter)
+
+      email = Email.invitation_email(invitation, "https://example.com/accept/1")
+
+      inviter_email = Authify.Accounts.User.get_primary_email_value(inviter)
+      assert email.html_body =~ "mailto:#{inviter_email}"
+    end
+
+    test "password reset footer uses generic admin contact message" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+
+      email = Email.password_reset_email(user, "https://example.com/reset/1")
+
+      assert email.html_body =~ "contact your organization administrator"
+      refute email.html_body =~ "mailto:"
+    end
+  end
+
+  describe "shared layout" do
+    test "all email types include the shared CSS and header" do
+      organization = organization_fixture()
+      user = user_for_organization_fixture(organization)
+      inviter = admin_user_fixture(organization)
+
+      invitation = create_invitation(organization, inviter)
+
+      invitation_email = Email.invitation_email(invitation, "https://example.com/accept/1")
+      reset_email = Email.password_reset_email(user, "https://example.com/reset/1")
+      verify_email = Email.email_verification_email(user, "https://example.com/verify/1")
+
+      for email <- [invitation_email, reset_email, verify_email] do
+        assert email.html_body =~ "<!DOCTYPE html>"
+        assert email.html_body =~ "font-family: -apple-system"
+        assert email.html_body =~ "border-bottom: 2px solid #0d6efd"
+        assert email.html_body =~ "Authify</h1>"
+        assert email.html_body =~ "class=\"footer\""
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the duplicated HTML document structure, CSS, header, and footer from the three email template functions in `Authify.Email` into shared helpers.

## Changes

- **Extracted `shared_css/0`** — single CSS block (was duplicated 3× across invitation, password reset, and email verification templates)
- **Extracted `email_layout/2`** — HTML document wrapper (DOCTYPE, head, style, body with header/footer)
- **Extracted `email_header/0`** — common header div with Authify branding
- **Extracted `email_footer/1` and `email_footer/2`** — footer with and without contact email link
- **Unified CSS class names** — `expiry-notice` and `security-notice` consolidated into `notice`
- **Normalized `send_invitation_email` and `send_password_reset_email`** to use `dev_or_test_mode?` (consistent with `send_email_verification_email`)
- **Removed unused `dev_mode?/0`** helper
- **Added 12 tests** — covering builders, send functions, datetime formatting, footer variants, and shared layout structure

## Stats

- `email.ex`: 174 insertions, 263 deletions (net −89 lines)
- New test file: `test/authify/email_test.exs` (12 tests, all passing)
- Full suite: 1,966 tests, 0 failures

Closes #116