### PR TITLE
refactor: centralize post-auth navigation logic into AuthifyWeb.Auth.Navigation

### DIFF
--- a/lib/authify_web/auth/navigation.ex
+++ b/lib/authify_web/auth/navigation.ex
@@ -1,13 +1,22 @@
 defmodule AuthifyWeb.Auth.Navigation do
   @moduledoc """
-  Provides shared post-authentication navigation logic.
+  Provides shared post-authentication navigation and session logic.
+
+  Centralizes logic that was previously duplicated across
+  `AuthifyWeb.SessionController` and `AuthifyWeb.MfaController`, such as
+  clearing MFA-related session keys, completing the MFA login flow, and
+  computing the dashboard path a user should be redirected to after
+  authentication.
   """
 
   use Phoenix.VerifiedRoutes,
     endpoint: AuthifyWeb.Endpoint,
     router: AuthifyWeb.Router
 
+  import Plug.Conn
+
   alias Authify.Accounts.User
+  alias Authify.MFA
 
   @doc """
   Returns the dashboard path for a user within an organization.
@@ -21,5 +30,36 @@ defmodule AuthifyWeb.Auth.Navigation do
     else
       ~p"/#{organization.slug}/user/dashboard"
     end
+  end
+
+  @doc """
+  Clears MFA-related session keys from the connection.
+
+  Removes the pending user/organization ids, the pending timestamp, and any
+  cached MFA setup secret. Used both during login completion and on logout
+  to ensure no stale MFA state remains in the session.
+  """
+  def clear_mfa_session(conn) do
+    conn
+    |> delete_session(:mfa_pending_user_id)
+    |> delete_session(:mfa_pending_organization_id)
+    |> delete_session(:mfa_pending_timestamp)
+    |> delete_session(:mfa_setup_secret)
+  end
+
+  @doc """
+  Completes the MFA login flow for a successfully verified user.
+
+  Clears the MFA rate limit for the user, signs them in via Guardian, stores
+  the current organization id in the session, and clears any remaining MFA
+  pending session keys. Returns the updated connection.
+  """
+  def complete_mfa_login(conn, user, organization) do
+    MFA.clear_rate_limit(user)
+
+    conn
+    |> Authify.Guardian.Plug.sign_in(user)
+    |> put_session(:current_organization_id, organization.id)
+    |> clear_mfa_session()
   end
 end

--- a/lib/authify_web/controllers/mfa_controller.ex
+++ b/lib/authify_web/controllers/mfa_controller.ex
@@ -646,7 +646,7 @@ defmodule AuthifyWeb.MfaController do
     conn
     |> Authify.Guardian.Plug.sign_in(updated_user)
     |> put_session(:current_organization_id, organization.id)
-    |> clear_mfa_session()
+    |> AuthifyWeb.Auth.Navigation.clear_mfa_session()
     |> put_flash(:info, "Welcome back!")
     |> redirect(
       to: AuthifyWeb.Auth.Navigation.dashboard_path_for_user(updated_user, organization)
@@ -817,14 +817,6 @@ defmodule AuthifyWeb.MfaController do
     end
   end
 
-  defp clear_mfa_session(conn) do
-    conn
-    |> delete_session(:mfa_pending_user_id)
-    |> delete_session(:mfa_pending_organization_id)
-    |> delete_session(:mfa_pending_timestamp)
-    |> delete_session(:mfa_setup_secret)
-  end
-
   # Determines the context for MFA setup (mandatory vs voluntary)
   # Returns {:ok, user, organization} or {:error, conn_with_redirect}
   defp get_setup_context(conn) do
@@ -863,21 +855,6 @@ defmodule AuthifyWeb.MfaController do
     else
       conn
     end
-  end
-
-  defp complete_mfa_login(conn, user, organization) do
-    # Clear rate limit on successful login
-    MFA.clear_rate_limit(user)
-
-    # Sign in and set organization
-    conn
-    |> Authify.Guardian.Plug.sign_in(user)
-    |> put_session(:current_organization_id, organization.id)
-    |> clear_mfa_session()
-  end
-
-  defp redirect_after_mfa_success(organization) do
-    "/#{organization.slug}/dashboard"
   end
 
   defp get_authentication_challenge(conn) do
@@ -925,11 +902,11 @@ defmodule AuthifyWeb.MfaController do
       }
     )
 
-    conn = complete_mfa_login(conn, user, organization)
+    conn = AuthifyWeb.Auth.Navigation.complete_mfa_login(conn, user, organization)
 
     json(conn, %{
       success: true,
-      redirect_url: redirect_after_mfa_success(organization)
+      redirect_url: AuthifyWeb.Auth.Navigation.dashboard_path_for_user(user, organization)
     })
   end
 

--- a/lib/authify_web/controllers/session_controller.ex
+++ b/lib/authify_web/controllers/session_controller.ex
@@ -175,7 +175,7 @@ defmodule AuthifyWeb.SessionController do
     conn =
       conn
       |> Guardian.Plug.sign_out()
-      |> clear_mfa_session()
+      |> AuthifyWeb.Auth.Navigation.clear_mfa_session()
 
     # Check if this is part of SAML Single Logout completion
     if slo_complete == "true" do
@@ -275,17 +275,8 @@ defmodule AuthifyWeb.SessionController do
     |> Guardian.Plug.sign_out()
     |> Guardian.Plug.sign_in(user)
     |> put_session(:current_organization_id, organization.id)
-    |> clear_mfa_session()
+    |> AuthifyWeb.Auth.Navigation.clear_mfa_session()
     |> put_flash(:info, "Welcome back!")
     |> redirect(to: AuthifyWeb.Auth.Navigation.dashboard_path_for_user(user, organization))
-  end
-
-  # Clear MFA-related session keys
-  defp clear_mfa_session(conn) do
-    conn
-    |> delete_session(:mfa_pending_user_id)
-    |> delete_session(:mfa_pending_organization_id)
-    |> delete_session(:mfa_pending_timestamp)
-    |> delete_session(:mfa_setup_secret)
   end
 end


### PR DESCRIPTION
## Summary

Addresses #118 — centralizes scattered post-authentication redirect logic.

### Changes
- Extract `clear_mfa_session/1` into `AuthifyWeb.Auth.Navigation` (was duplicated identically in `SessionController` and `MfaController`)
- Extract `complete_mfa_login/3` into `AuthifyWeb.Auth.Navigation` 
- Remove `redirect_after_mfa_success/1` and fix latent bug: WebAuthn success redirect now uses `dashboard_path_for_user/2` which respects admin vs non-admin routing (previously hardcoded admin dashboard for all users)
- Both controllers now delegate to `Navigation` for session cleanup and login completion

### Test Plan
- [x] `mix test test/authify_web/controllers/session_controller_test.exs` passes
- [x] `mix test test/authify_web/controllers/mfa_controller_test.exs` passes
- [x] `mix compile --warning-as-errors` clean

Closes #118