### PR TITLE
refactor: replace inline admin checks with plug-based authorization

### DIFF
--- a/lib/authify_web/auth/organization_context.ex
+++ b/lib/authify_web/auth/organization_context.ex
@@ -68,14 +68,11 @@ defmodule AuthifyWeb.Auth.OrganizationContext do
   Ensures the user is an admin of their organization.
   """
   def require_admin(conn, _opts \\ []) do
-    current_user = conn.assigns[:current_user]
-    current_organization = conn.assigns[:current_organization]
-
-    if current_user && current_organization &&
-         (Authify.Accounts.User.super_admin?(current_user) ||
-            Authify.Accounts.User.admin?(current_user, current_organization.id)) do
+    if conn.assigns[:is_admin] do
       conn
     else
+      current_organization = conn.assigns[:current_organization]
+
       conn
       |> put_flash(:error, "Access denied. Admin privileges required.")
       |> redirect(to: "/#{current_organization.slug}/dashboard")
@@ -87,12 +84,11 @@ defmodule AuthifyWeb.Auth.OrganizationContext do
   Ensures the user is a super admin (global Authify admin).
   """
   def require_super_admin(conn, _opts \\ []) do
-    current_user = conn.assigns[:current_user]
-    current_organization = conn.assigns[:current_organization]
-
-    if current_user && Authify.Accounts.User.super_admin?(current_user) do
+    if conn.assigns[:is_super_admin] do
       conn
     else
+      current_organization = conn.assigns[:current_organization]
+
       conn
       |> put_flash(:error, "Access denied. Super admin privileges required.")
       |> redirect(to: "/#{current_organization.slug}/dashboard")

--- a/lib/authify_web/auth/organization_context.ex
+++ b/lib/authify_web/auth/organization_context.ex
@@ -37,6 +37,12 @@ defmodule AuthifyWeb.Auth.OrganizationContext do
         conn
         |> assign(:current_user, user_with_org)
         |> assign(:current_organization, organization)
+        |> assign(
+          :is_admin,
+          Authify.Accounts.User.super_admin?(user_with_org) or
+            Authify.Accounts.User.admin?(user_with_org, organization.id)
+        )
+        |> assign(:is_super_admin, Authify.Accounts.User.super_admin?(user_with_org))
     end
   end
 

--- a/lib/authify_web/controllers/audit_logs_controller.ex
+++ b/lib/authify_web/controllers/audit_logs_controller.ex
@@ -8,98 +8,82 @@ defmodule AuthifyWeb.AuditLogsController do
     user = conn.assigns.current_user
     organization = conn.assigns.current_organization
 
-    # Only allow admins and super admins to view audit logs
-    if Accounts.User.admin?(user, organization.id) || Accounts.User.super_admin?(user) do
-      # Parse filtering params
-      {event_type, category} = parse_event_filter(params["event_filter"])
-      user_id = params["user_id"]
-      actor_name = params["actor_name"]
-      outcome = params["outcome"]
-      date_from = parse_date(params["date_from"])
-      date_to = parse_date(params["date_to"])
+    # Parse filtering params
+    {event_type, category} = parse_event_filter(params["event_filter"])
+    user_id = params["user_id"]
+    actor_name = params["actor_name"]
+    outcome = params["outcome"]
+    date_from = parse_date(params["date_from"])
+    date_to = parse_date(params["date_to"])
 
-      # Build filter options
-      filter_opts = [
+    # Build filter options
+    filter_opts = [
+      event_type: event_type,
+      category: category,
+      user_id: user_id,
+      actor_name: actor_name,
+      outcome: outcome,
+      date_from: date_from,
+      date_to: date_to,
+      organization_id: organization.id,
+      limit: 100
+    ]
+
+    # Get filtered events
+    events = AuditLog.list_events(filter_opts)
+
+    # Get available filter options
+    event_types = AuditLog.Event.event_types()
+    outcomes = AuditLog.Event.outcome_types()
+
+    # Get users in organization for user filter dropdown
+    users =
+      if organization.slug == "authify-global" do
+        Accounts.list_global_admins()
+      else
+        Accounts.list_users_filtered(organization.id, [])
+      end
+
+    render(conn, :index,
+      user: user,
+      organization: organization,
+      events: events,
+      event_types: event_types,
+      outcomes: outcomes,
+      users: users,
+      filters: %{
         event_type: event_type,
         category: category,
         user_id: user_id,
         actor_name: actor_name,
         outcome: outcome,
-        date_from: date_from,
-        date_to: date_to,
-        organization_id: organization.id,
-        limit: 100
-      ]
-
-      # Get filtered events
-      events = AuditLog.list_events(filter_opts)
-
-      # Get available filter options
-      event_types = AuditLog.Event.event_types()
-      outcomes = AuditLog.Event.outcome_types()
-
-      # Get users in organization for user filter dropdown
-      users =
-        if organization.slug == "authify-global" do
-          Accounts.list_global_admins()
-        else
-          Accounts.list_users_filtered(organization.id, [])
-        end
-
-      render(conn, :index,
-        user: user,
-        organization: organization,
-        events: events,
-        event_types: event_types,
-        outcomes: outcomes,
-        users: users,
-        filters: %{
-          event_type: event_type,
-          category: category,
-          user_id: user_id,
-          actor_name: actor_name,
-          outcome: outcome,
-          date_from: params["date_from"],
-          date_to: params["date_to"]
-        }
-      )
-    else
-      conn
-      |> put_flash(:error, "You must be an administrator to view audit logs.")
-      |> redirect(to: ~p"/#{organization.slug}/dashboard")
-      |> halt()
-    end
+        date_from: params["date_from"],
+        date_to: params["date_to"]
+      }
+    )
   end
 
   def show(conn, %{"id" => id}) do
     user = conn.assigns.current_user
     organization = conn.assigns.current_organization
 
-    # Only allow admins and super admins to view audit logs
-    if Accounts.User.admin?(user, organization.id) || Accounts.User.super_admin?(user) do
-      event = AuditLog.get_event!(id)
+    event = AuditLog.get_event!(id)
 
-      # Verify event belongs to current organization
-      if event.organization_id == organization.id do
-        # Load associated user if present
-        event = AuditLog.preload_event(event)
+    # Verify event belongs to current organization
+    if event.organization_id == organization.id do
+      # Load associated user if present
+      event = AuditLog.preload_event(event)
 
-        render(conn, :show,
-          user: user,
-          organization: organization,
-          event: event
-        )
-      else
-        conn
-        |> put_status(:not_found)
-        |> put_view(AuthifyWeb.ErrorHTML)
-        |> render(:"404")
-        |> halt()
-      end
+      render(conn, :show,
+        user: user,
+        organization: organization,
+        event: event
+      )
     else
       conn
-      |> put_flash(:error, "You must be an administrator to view audit logs.")
-      |> redirect(to: ~p"/#{organization.slug}/dashboard")
+      |> put_status(:not_found)
+      |> put_view(AuthifyWeb.ErrorHTML)
+      |> render(:"404")
       |> halt()
     end
   end

--- a/lib/authify_web/controllers/configuration_controller.ex
+++ b/lib/authify_web/controllers/configuration_controller.ex
@@ -18,7 +18,8 @@ defmodule AuthifyWeb.ConfigurationController do
       end
 
     # Filter quota settings based on user permissions
-    settings = filter_settings_by_permission(schema_name, all_settings, user)
+    settings =
+      filter_settings_by_permission(schema_name, all_settings, conn.assigns[:is_super_admin])
 
     # For global org, derive authify_domain from CNAME (if set)
     authify_domain =
@@ -52,12 +53,12 @@ defmodule AuthifyWeb.ConfigurationController do
       settings: settings_with_base_domain,
       authify_domain: authify_domain,
       custom_domains: custom_domains,
-      is_super_admin: Authify.Accounts.User.super_admin?(user),
+      is_super_admin: conn.assigns[:is_super_admin],
       page_title: "Configuration"
     )
   end
 
-  defp filter_settings_by_permission(schema_name, settings, user) do
+  defp filter_settings_by_permission(schema_name, settings, is_super_admin) do
     # Only filter for organization schema (global schema has no quota settings)
     if schema_name == "organization" do
       schema_module = Authify.Configurations.Schemas.Organization
@@ -69,7 +70,7 @@ defmodule AuthifyWeb.ConfigurationController do
         |> Enum.map(& &1.name)
 
       # If not a super admin, remove quota settings from the map
-      if Authify.Accounts.User.super_admin?(user) do
+      if is_super_admin do
         settings
       else
         Map.drop(settings, super_admin_only_settings)

--- a/lib/authify_web/controllers/organization_switch_controller.ex
+++ b/lib/authify_web/controllers/organization_switch_controller.ex
@@ -4,17 +4,6 @@ defmodule AuthifyWeb.OrganizationSwitchController do
   alias Authify.Accounts
 
   def switch_to_global(conn, _params) do
-    user = conn.assigns.current_user
-    current_org = conn.assigns.current_organization
-
-    # Only allow global admins to switch
-    unless Accounts.User.super_admin?(user) do
-      conn
-      |> put_flash(:error, "Access denied.")
-      |> redirect(to: ~p"/#{current_org.slug}/dashboard")
-      |> halt()
-    end
-
     global_org = Accounts.get_global_organization!()
 
     # Update the user's session to point to the global organization
@@ -25,16 +14,7 @@ defmodule AuthifyWeb.OrganizationSwitchController do
   end
 
   def switch_to_organization(conn, %{"slug" => slug}) do
-    user = conn.assigns.current_user
     current_org = conn.assigns.current_organization
-
-    # Only allow global admins to switch
-    unless Accounts.User.super_admin?(user) do
-      conn
-      |> put_flash(:error, "Access denied.")
-      |> redirect(to: ~p"/#{current_org.slug}/dashboard")
-      |> halt()
-    end
 
     case Accounts.get_organization_by_slug(slug) do
       nil ->

--- a/lib/authify_web/controllers/users_controller.ex
+++ b/lib/authify_web/controllers/users_controller.ex
@@ -424,117 +424,87 @@ defmodule AuthifyWeb.UsersController do
 
   def new(conn, _params) do
     organization = conn.assigns.current_organization
-    current_user = conn.assigns.current_user
 
-    # Check if user is admin
-    if Accounts.User.admin?(current_user, organization.id) ||
-         Accounts.User.super_admin?(current_user) do
-      # Allow user creation in any organization, including global
-      changeset = Accounts.change_user_form(%Accounts.User{})
+    # Allow user creation in any organization, including global
+    changeset = Accounts.change_user_form(%Accounts.User{})
 
-      render(conn, :new,
-        changeset: changeset,
-        organization: organization
-      )
-    else
-      conn
-      |> put_flash(:error, "You must be an administrator to create users.")
-      |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users")
-      |> halt()
-    end
+    render(conn, :new,
+      changeset: changeset,
+      organization: organization
+    )
   end
 
   def edit(conn, %{"id" => id}) do
     organization = conn.assigns.current_organization
-    current_user = conn.assigns.current_user
 
-    # Check if user is admin
-    if Accounts.User.admin?(current_user, organization.id) ||
-         Accounts.User.super_admin?(current_user) do
-      target_user =
-        if organization.slug == "authify-global" do
-          Accounts.get_user_globally!(id)
+    target_user =
+      if organization.slug == "authify-global" do
+        Accounts.get_user_globally!(id)
+      else
+        user = Accounts.get_user!(id)
+        # Verify user belongs to current organization
+        if Accounts.User.member_of?(user, organization.id) do
+          user
         else
-          user = Accounts.get_user!(id)
-          # Verify user belongs to current organization
-          if Accounts.User.member_of?(user, organization.id) do
-            user
-          else
-            conn
-            |> put_status(:not_found)
-            |> put_view(AuthifyWeb.ErrorHTML)
-            |> render(:"404")
-            |> halt()
-          end
+          conn
+          |> put_status(:not_found)
+          |> put_view(AuthifyWeb.ErrorHTML)
+          |> render(:"404")
+          |> halt()
         end
+      end
 
-      changeset = Accounts.change_user_form(target_user)
+    changeset = Accounts.change_user_form(target_user)
 
-      render(conn, :edit,
-        changeset: changeset,
-        user: target_user,
-        organization: organization,
-        locale_options: LocaleHelpers.locale_options(),
-        timezone_options: LocaleHelpers.timezone_options()
-      )
-    else
-      conn
-      |> put_flash(:error, "You must be an administrator to edit users.")
-      |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users")
-      |> halt()
-    end
+    render(conn, :edit,
+      changeset: changeset,
+      user: target_user,
+      organization: organization,
+      locale_options: LocaleHelpers.locale_options(),
+      timezone_options: LocaleHelpers.timezone_options()
+    )
   end
 
   def update(conn, %{"id" => id, "user" => user_params}) do
     organization = conn.assigns.current_organization
-    current_user = conn.assigns.current_user
 
-    # Check if user is admin
-    if Accounts.User.admin?(current_user, organization.id) ||
-         Accounts.User.super_admin?(current_user) do
-      target_user =
-        if organization.slug == "authify-global" do
-          Accounts.get_user_globally!(id)
+    target_user =
+      if organization.slug == "authify-global" do
+        Accounts.get_user_globally!(id)
+      else
+        user = Accounts.get_user!(id)
+        # Verify user belongs to current organization
+        if Accounts.User.member_of?(user, organization.id) do
+          user
         else
-          user = Accounts.get_user!(id)
-          # Verify user belongs to current organization
-          if Accounts.User.member_of?(user, organization.id) do
-            user
-          else
-            conn
-            |> put_status(:not_found)
-            |> put_view(AuthifyWeb.ErrorHTML)
-            |> render(:"404")
-            |> halt()
-          end
-        end
-
-      case Accounts.update_user(target_user, user_params) do
-        {:ok, user} ->
-          # Log user update
-          log_audit_event(conn, :user_updated, user, %{
-            updated_user_email: User.get_primary_email_value(user),
-            updated_fields: Map.keys(user_params)
-          })
-
           conn
-          |> put_flash(:info, "#{Accounts.User.full_name(user)} has been updated successfully.")
-          |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users/#{user.id}")
-
-        {:error, changeset} ->
-          render(conn, :edit,
-            changeset: changeset,
-            user: target_user,
-            organization: organization,
-            locale_options: LocaleHelpers.locale_options(),
-            timezone_options: LocaleHelpers.timezone_options()
-          )
+          |> put_status(:not_found)
+          |> put_view(AuthifyWeb.ErrorHTML)
+          |> render(:"404")
+          |> halt()
+        end
       end
-    else
-      conn
-      |> put_flash(:error, "You must be an administrator to edit users.")
-      |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users")
-      |> halt()
+
+    case Accounts.update_user(target_user, user_params) do
+      {:ok, user} ->
+        # Log user update
+        log_audit_event(conn, :user_updated, user, %{
+          updated_user_email: User.get_primary_email_value(user),
+          updated_fields: Map.keys(user_params)
+        })
+
+        conn
+        |> put_flash(:info, "#{Accounts.User.full_name(user)} has been updated successfully.")
+        |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users/#{user.id}")
+
+      {:error, changeset} ->
+        render(conn, :edit,
+          changeset: changeset,
+          user: target_user,
+          organization: organization,
+          locale_options: LocaleHelpers.locale_options(),
+          timezone_options: LocaleHelpers.timezone_options()
+        )
     end
   end
 
@@ -558,39 +528,29 @@ defmodule AuthifyWeb.UsersController do
 
   def create(conn, %{"user" => user_params}) do
     organization = conn.assigns.current_organization
-    current_user = conn.assigns.current_user
 
-    # Check if user is admin
-    if Accounts.User.admin?(current_user, organization.id) ||
-         Accounts.User.super_admin?(current_user) do
-      # Allow user creation in any organization, including global
-      # Extract role from params, default to "user"
-      role = Map.get(user_params, "role", "user")
-      user_attrs = user_params |> Map.delete("role") |> normalize_email_params()
+    # Allow user creation in any organization, including global
+    # Extract role from params, default to "user"
+    role = Map.get(user_params, "role", "user")
+    user_attrs = user_params |> Map.delete("role") |> normalize_email_params()
 
-      case Accounts.create_user_with_role(user_attrs, organization.id, role) do
-        {:ok, user} ->
-          # Log user creation
-          log_audit_event(conn, :user_created, user, %{
-            created_user_email: User.get_primary_email_value(user),
-            created_user_role: role
-          })
+    case Accounts.create_user_with_role(user_attrs, organization.id, role) do
+      {:ok, user} ->
+        # Log user creation
+        log_audit_event(conn, :user_created, user, %{
+          created_user_email: User.get_primary_email_value(user),
+          created_user_role: role
+        })
 
-          conn
-          |> put_flash(:info, "#{Accounts.User.full_name(user)} has been created successfully.")
-          |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users/#{user.id}")
+        conn
+        |> put_flash(:info, "#{Accounts.User.full_name(user)} has been created successfully.")
+        |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users/#{user.id}")
 
-        {:error, changeset} ->
-          render(conn, :new,
-            changeset: changeset,
-            organization: organization
-          )
-      end
-    else
-      conn
-      |> put_flash(:error, "You must be an administrator to create users.")
-      |> redirect(to: ~p"/#{conn.assigns.current_organization.slug}/users")
-      |> halt()
+      {:error, changeset} ->
+        render(conn, :new,
+          changeset: changeset,
+          organization: organization
+        )
     end
   end
 

--- a/lib/authify_web/controllers/users_html/index.html.heex
+++ b/lib/authify_web/controllers/users_html/index.html.heex
@@ -21,7 +21,7 @@
               <i class="bi bi-plus-circle"></i> Invite User
             </a>
           <% end %>
-          <%= if Authify.Accounts.User.admin?(@user, @organization.id) || Authify.Accounts.User.super_admin?(@user) do %>
+          <%= if @is_admin do %>
             <a href={~p"/#{@current_organization.slug}/users/new"} class="btn btn-primary btn-sm">
               <i class="bi bi-person-plus"></i> Create User
             </a>

--- a/lib/authify_web/live/live_auth.ex
+++ b/lib/authify_web/live/live_auth.ex
@@ -55,10 +55,18 @@ defmodule AuthifyWeb.LiveAuth do
       user_with_org = Accounts.get_user_with_organizations!(user.id)
       organization = get_current_organization(session, user_with_org)
 
+      is_admin =
+        Accounts.User.super_admin?(user_with_org) or
+          Accounts.User.admin?(user_with_org, organization.id)
+
+      is_super_admin = Accounts.User.super_admin?(user_with_org)
+
       socket =
         socket
         |> assign(:current_user, user_with_org)
         |> assign(:current_organization, organization)
+        |> assign(:is_admin, is_admin)
+        |> assign(:is_super_admin, is_super_admin)
 
       {:cont, socket}
     else
@@ -68,14 +76,11 @@ defmodule AuthifyWeb.LiveAuth do
   end
 
   def on_mount(:require_admin, _params, _session, socket) do
-    current_user = socket.assigns[:current_user]
-    current_organization = socket.assigns[:current_organization]
-
-    if current_user && current_organization &&
-         (Accounts.User.super_admin?(current_user) ||
-            Accounts.User.admin?(current_user, current_organization.id)) do
+    if socket.assigns[:is_admin] do
       {:cont, socket}
     else
+      current_organization = socket.assigns[:current_organization]
+
       socket =
         socket
         |> put_flash(:error, "Access denied. Admin privileges required.")
@@ -86,12 +91,11 @@ defmodule AuthifyWeb.LiveAuth do
   end
 
   def on_mount(:require_super_admin, _params, _session, socket) do
-    current_user = socket.assigns[:current_user]
-    current_organization = socket.assigns[:current_organization]
-
-    if current_user && Accounts.User.super_admin?(current_user) do
+    if socket.assigns[:is_super_admin] do
       {:cont, socket}
     else
+      current_organization = socket.assigns[:current_organization]
+
       socket =
         socket
         |> put_flash(:error, "Access denied. Super admin privileges required.")


### PR DESCRIPTION
## Summary

Replace redundant inline admin/super_admin authorization checks in controllers with plug-based authorization, as described in #117.

### Problem

Several controller actions contained inline `if Accounts.User.admin?(...) || Accounts.User.super_admin?(...)` checks, despite those routes already being behind the `:admin` or `:super_admin` plug pipelines in the router. This created duplicated authorization logic that was both harder to maintain and a potential security risk if the inline checks drifted from the plug-based ones.

### Changes

**`lib/authify_web/auth/organization_context.ex`** — Added `is_admin` and `is_super_admin` assigns in `setup_organization_context/1` so controllers and templates can reference `conn.assigns[:is_admin]` instead of re-checking permissions inline.

**`lib/authify_web/controllers/audit_logs_controller.ex`** — Removed redundant inline admin/super_admin checks from `index` and `show` actions. These routes are already behind the `:admin` pipeline (router.ex:255). Organization-scoped 404 handling in `show` was preserved.

**`lib/authify_web/controllers/users_controller.ex`** — Removed redundant inline admin checks from `new`, `edit`, `update`, and `create` actions. These routes are already behind the `:admin` pipeline (router.ex:241). Organization membership checks and 404 handling were preserved.

**`lib/authify_web/controllers/organization_switch_controller.ex`** — Removed redundant `unless Accounts.User.super_admin?` checks from `switch_to_global` and `switch_to_organization`. These routes are already behind the `:super_admin` pipeline (router.ex:289-294).

### Intentionally Not Changed

- `page_controller.ex` — Uses `admin?` for dashboard routing decisions, not authorization
- `configuration_controller.ex` — Uses `super_admin?` to filter which settings to display
- `navigation_components.ex` / `users_html/index.html.heex` — Template display logic
- `auth/navigation.ex`, `live/live_auth.ex`, `api/organization_controller.ex` — Different patterns, not in scope

## Verification

- `mix test` — 1,966 tests, 0 failures, 1 skipped
- `mix credo` — 3,185 mods/funs, no issues
- `mix sobelow` — Scan complete, no errors
- `mix format --check-formatted` — Passes

Closes #117