### PR TITLE
chore: bump version to 0.17.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.17.0",
+      version: "0.17.1",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
## Summary

Bump version from `0.17.0` to `0.17.1` in preparation for the `v0.17.1` release tag.