### PR TITLE
fix: use millisecond resolution for health cache TTL to fix flaky test

### DIFF
--- a/lib/authify_web/controllers/health_controller.ex
+++ b/lib/authify_web/controllers/health_controller.ex
@@ -16,12 +16,12 @@ defmodule AuthifyWeb.HealthController do
   """
 
   @cache_table :health_check_cache
-  @cache_ttl_seconds 1
+  @cache_ttl_ms 1_000
 
   @doc """
   Health check endpoint that verifies:
   - Application is running
-  - Database connectivity (cached for #{@cache_ttl_seconds} second)
+  - Database connectivity (cached for 1 second)
 
   Returns 200 OK if healthy, 503 Service Unavailable if unhealthy.
   """
@@ -80,7 +80,7 @@ defmodule AuthifyWeb.HealthController do
 
   defp cache_health_status(status) do
     ensure_cache_table_exists()
-    :ets.insert(@cache_table, {:health_status, status, System.monotonic_time(:second)})
+    :ets.insert(@cache_table, {:health_status, status, System.monotonic_time(:millisecond)})
   rescue
     ArgumentError ->
       # If table creation fails due to race condition, ignore
@@ -88,8 +88,8 @@ defmodule AuthifyWeb.HealthController do
   end
 
   defp cache_fresh?(cached_at) do
-    now = System.monotonic_time(:second)
-    now - cached_at < @cache_ttl_seconds
+    now = System.monotonic_time(:millisecond)
+    now - cached_at < @cache_ttl_ms
   end
 
   defp ensure_cache_table_exists do

--- a/test/authify/email_test.exs
+++ b/test/authify/email_test.exs
@@ -1,7 +1,6 @@
 defmodule Authify.EmailTest do
   use Authify.DataCase, async: true
 
-  import Swoosh.TestAssertions
   import Authify.AccountsFixtures
 
   alias Authify.Email


### PR DESCRIPTION
## Problem

The `test GET /health caches response for 1 second` test was flaky in CI. Two back-to-back requests would occasionally produce different timestamps despite the 1-second cache TTL.

## Root Cause

The health check cache used `System.monotonic_time(:second)` (integer-second resolution) with a 1-second TTL. Two requests straddling a monotonic-time second boundary (e.g. at `...19.52s` and `...19.57s`) would both see the cache as stale, triggering fresh DB queries and producing different timestamps.

## Fix

Switch to millisecond resolution (`:millisecond` + `@cache_ttl_ms 1_000`) so the 1-second window is precise and consistent regardless of sub-second timing.

## Testing

- All 6 health controller tests pass consistently
- `mix precommit` passes (1966 tests, credo, sobelow)

---

## Bonus: Remove unused import

Also removed an unused `Swoosh.TestAssertions` import from `test/authify/email_test.exs` that was producing a compiler warning in CI. The email tests inspect `Swoosh.Email` structs directly and don't use Swoosh's assertion helpers.