### PR TITLE
Upgrade to Elixir 1.20.3 / OTP 29.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - elixir: '1.20.3'
-            otp: '29.0.5'
-          # Elixir main branch = latest dev/edge, built against OTP 29.
-          - elixir: 'main'
-            otp: '29.0.5'
+        elixir: ['1.20.3', 'main']
+        otp: ['29.0.5']
         partition: [1, 2, 3, 4]
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   MIX_ENV: test
-  ELIXIR_VERSION: '1.19.5'
-  OTP_VERSION: '28.5.0.5'
+  ELIXIR_VERSION: '1.20.3'
+  OTP_VERSION: '29.0.5'
 
 jobs:
   test:
@@ -19,8 +19,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.19.5']
-        otp: ['28.5.0.5']
+        include:
+          - elixir: '1.20.3'
+            otp: '29.0.5'
+          # Elixir main branch = latest dev/edge, built against OTP 29.
+          - elixir: 'main'
+            otp: '29.0.5'
         partition: [1, 2, 3, 4]
 
     services:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 28.5.0.5
-elixir 1.19.5-otp-28
+erlang 29.0.5
+elixir 1.20.3-otp-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-23
+
+### Changed
+
+- Upgraded to Elixir 1.20.3 and Erlang/OTP 29.0.5
+- CI now tests on both Elixir 1.20.3 and the `main` branch (dev/edge)
+
+### Fixed
+
+- Resolved warnings introduced by Elixir 1.20's stricter typechecker
+- Fixed MFA lockout so it can actually be disabled (`|| true` always evaluated truthy)
+
 ## [0.18.0] - 2026-08-23
 
 ### Changed
@@ -722,7 +734,8 @@ Initial release of Authify - Multi-tenant Identity Provider
 - Prometheus metrics with telemetry
 - Bandit web server
 
-[Unreleased]: https://github.com/authify/authify/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/authify/authify/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/authify/authify/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/authify/authify/compare/v0.12.3...v0.18.0
 [0.12.3]: https://github.com/authify/authify/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/authify/authify/compare/v0.12.1...v0.12.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.18.4-erlang-26.2.5-debian-bullseye-20240904-slim
 #
-ARG ELIXIR_VERSION=1.19.5
-ARG OTP_VERSION=28.5.0.5
+ARG ELIXIR_VERSION=1.20.3
+ARG OTP_VERSION=29.0.5
 ARG DEBIAN_VERSION=trixie-20260803-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"

--- a/lib/authify/mfa.ex
+++ b/lib/authify/mfa.ex
@@ -377,9 +377,10 @@ defmodule Authify.MFA do
   - mfa_lockout_duration_minutes: Lockout duration (default: 5)
   """
   def check_rate_limit(%User{} = user, organization) do
-    # Check if lockout is enabled for this organization
+    # Check if lockout is enabled for this organization.
+    # Defaults to enabled unless explicitly set to false.
     lockout_enabled =
-      Authify.Configurations.get_organization_setting(organization, :mfa_lockout_enabled) || true
+      Authify.Configurations.get_organization_setting(organization, :mfa_lockout_enabled) != false
 
     if lockout_enabled do
       # Get org settings

--- a/lib/authify/mfa/webauthn.ex
+++ b/lib/authify/mfa/webauthn.ex
@@ -428,7 +428,7 @@ defmodule Authify.MFA.WebAuthn do
     if at_flag do
       # Parse attested credential data
       <<aaguid::binary-size(16), cred_id_len::16, rest::binary>> = credential_data
-      <<credential_id::binary-size(cred_id_len), public_key_cbor::binary>> = rest
+      <<credential_id::binary-size(^cred_id_len), public_key_cbor::binary>> = rest
 
       # Decode public key (COSE format)
       case CBOR.decode(public_key_cbor) do

--- a/lib/authify/saml/xml.ex
+++ b/lib/authify/saml/xml.ex
@@ -36,7 +36,6 @@ defmodule Authify.SAML.XML do
   end
 
   def parse_authn_request(nil), do: {:error, "SAML request cannot be empty"}
-  def parse_authn_request(""), do: {:error, "SAML request cannot be empty"}
 
   @doc """
   Parse a SAML LogoutRequest from XML or Base64-encoded XML.
@@ -63,7 +62,6 @@ defmodule Authify.SAML.XML do
   end
 
   def parse_logout_request(nil), do: {:error, "SAML logout request cannot be empty"}
-  def parse_logout_request(""), do: {:error, "SAML logout request cannot be empty"}
 
   @doc """
   Generate a SAML Response with Assertion, optionally signed.

--- a/lib/authify/scim_client/event_handler.ex
+++ b/lib/authify/scim_client/event_handler.ex
@@ -5,8 +5,6 @@ defmodule Authify.SCIMClient.EventHandler do
   """
   use GenServer
 
-  require Logger
-
   alias Authify.SCIMClient.Provisioner
 
   def start_link(opts) do

--- a/lib/authify/tasks/workers/task_executor.ex
+++ b/lib/authify/tasks/workers/task_executor.ex
@@ -27,7 +27,6 @@ defmodule Authify.Tasks.Workers.TaskExecutor do
   alias Authify.Tasks.Telemetry, as: TaskTelemetry
 
   @active_states Task.active_states()
-  @transitioning_states Task.transitioning_states()
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"task_id" => task_id}}) do
@@ -177,10 +176,6 @@ defmodule Authify.Tasks.Workers.TaskExecutor do
 
       %Task{status: :skipping} ->
         handler.on_skipping(duplicate, task)
-
-      %Task{status: status} when status in @transitioning_states ->
-        # Catch-all for any new transitioning states
-        :wait
     end
   end
 

--- a/lib/authify_web/plugs/rate_limiter.ex
+++ b/lib/authify_web/plugs/rate_limiter.ex
@@ -23,7 +23,6 @@ defmodule AuthifyWeb.Plugs.RateLimiter do
   """
 
   import Plug.Conn
-  require Logger
 
   @behaviour Plug
 
@@ -144,11 +143,6 @@ defmodule AuthifyWeb.Plugs.RateLimiter do
           |> put_resp_header("retry-after", to_string(retry_after))
           |> send_rate_limit_response()
           |> halt()
-
-        {:error, reason} ->
-          # Log the error but don't block the request
-          Logger.error("Rate limiting error for #{bucket_key}: #{inspect(reason)}")
-          conn
       end
     else
       # Rate limiting disabled, allow all requests

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Authify.MixProject do
     [
       app: :authify,
       version: "0.18.0",
-      elixir: "~> 1.19",
+      elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.18.0",
+      version: "0.19.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/protocol_clients/saml_service_provider_test.exs
+++ b/test/protocol_clients/saml_service_provider_test.exs
@@ -56,7 +56,7 @@ defmodule AuthifyTest.SAMLServiceProviderTest do
       sp = SAMLServiceProvider.new(org)
       assert {:ok, {encoded, request_id}} = SAMLServiceProvider.build_authn_request(sp)
       assert is_binary(encoded)
-      assert is_binary(request_id) and String.starts_with?(request_id, "_")
+      assert String.starts_with?(request_id, "_")
       xml = Base.decode64!(encoded)
       assert String.contains?(xml, "<?xml")
       assert String.contains?(xml, "<saml2p:AuthnRequest")


### PR DESCRIPTION
## Summary

Upgrades the toolchain to Elixir 1.20.3 and Erlang/OTP 29.0.5, and makes the codebase compatible with the stricter warnings-as-errors compile introduced by Elixir 1.20.

## Changes

- **Toolchain bump** across `mix.exs`, `.tool-versions`, `Dockerfile`, and CI
- **CI matrix** now tests both Elixir `1.20.3` and the `main` branch (dev/edge), both against OTP 29
- **Elixir 1.20 compatibility fixes** for new warnings:
  - Pin bitstring size in `webauthn` (`binary-size(^cred_id_len)`)
  - MFA lockout default fixed (`|| true` always evaluated truthy; now `!= false`)
  - Removed dead `{:error, reason}` clause in `rate_limiter` (Hammer only returns `{:allow,_}|{:deny,_}`)
  - Removed dead `""` clauses in `saml/xml`
  - Removed redundant transitioning-state catch-all in `task_executor`
  - Removed unused `Logger` requires

## Verification

- `mix compile --warnings-as-errors` clean (dev + test env)
- `mix test`: 1965 passed, 1 skipped
- `mix precommit` (format, credo, sobelow): clean

## Version

Bumps version to `0.19.0` (minor — new toolchain, no breaking API change).

After this merges to `main`, we'll cut the v0.19.0 release using the release skill.