### PR TITLE
Fix deadlock: seed tenant_base_domain via migration

### DIFF
--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -9,3 +9,5 @@ Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:472,6D1EA51
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:17,6E55B0E
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:80,7C3BA2
 Config.CSRF: Missing CSRF Protections,lib/authify_web/router.ex:14,88CB4F
+SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:232,2BA0D0E
+SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:256,6C40D4C

--- a/.sobelow-skips
+++ b/.sobelow-skips
@@ -1,4 +1,3 @@
-
 XSS.SendResp: XSS in `send_resp`,lib/authify_web/controllers/saml_controller.ex:467,1D3AE37
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:69,469F306
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:10,4723B64
@@ -9,5 +8,5 @@ Config.CSRFRoute: CSRF via Action Reuse,lib/authify_web/router.ex:472,6D1EA51
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:17,6E55B0E
 Config.CSP: Missing Content-Security-Policy,lib/authify_web/router.ex:80,7C3BA2
 Config.CSRF: Missing CSRF Protections,lib/authify_web/router.ex:14,88CB4F
-SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:232,2BA0D0E
-SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:256,6C40D4C
+SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:198,3B7FEA5
+SQL.Query: SQL injection,lib/authify_web/controllers/maintenance_controller.ex:222,3524CA7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-08-24
+
+### Fixed
+
+- Fixed MySQL deadlock (1213) in configuration value upsert — `upsert_configuration_value/3` now uses an atomic `ON DUPLICATE KEY UPDATE` instead of a check-then-insert TOCTOU race
+- Fixed MFA lockout so it can actually be disabled (`|| true` always evaluated truthy)
+
+### Changed
+
+- Replaced hardcoded placeholder maintenance page data with real BEAM VM stats (memory, schedulers, run queue, process count), real MySQL database/table sizes, and real Oban pending job count
+- Removed placeholder backup, orphaned sessions, temp files, and maintenance logs from the maintenance page
+- Seeded `tenant_base_domain` via a test-only migration to eliminate concurrent-write deadlocks in async tests
+
 ## [0.19.0] - 2026-08-23
 
 ### Changed
@@ -734,7 +747,8 @@ Initial release of Authify - Multi-tenant Identity Provider
 - Prometheus metrics with telemetry
 - Bandit web server
 
-[Unreleased]: https://github.com/authify/authify/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/authify/authify/compare/v0.19.1...HEAD
+[0.19.1]: https://github.com/authify/authify/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/authify/authify/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/authify/authify/compare/v0.12.3...v0.18.0
 [0.12.3]: https://github.com/authify/authify/compare/v0.12.2...v0.12.3

--- a/lib/authify/configurations.ex
+++ b/lib/authify/configurations.ex
@@ -289,24 +289,23 @@ defmodule Authify.Configurations do
   defp upsert_configuration_value(config, setting_name, value) do
     setting_name_str = to_string(setting_name)
 
-    existing =
-      config.configuration_values
-      |> Enum.find(&(&1.setting_name == setting_name_str))
-
+    # Atomically insert or update the value using the unique index on
+    # (configuration_id, setting_name). Previously this did a check-then-insert
+    # (TOCTOU), which deadlocked when concurrent processes both found no row and
+    # then inserted the same key. A single ON DUPLICATE KEY UPDATE eliminates
+    # the race in both tests and production.
     result =
-      if existing do
-        existing
-        |> ConfigurationValue.changeset(%{value: value})
-        |> Repo.update()
-      else
-        %ConfigurationValue{}
-        |> ConfigurationValue.changeset(%{
-          configuration_id: config.id,
-          setting_name: setting_name_str,
-          value: value
-        })
-        |> Repo.insert()
-      end
+      %ConfigurationValue{}
+      |> ConfigurationValue.changeset(%{
+        configuration_id: config.id,
+        setting_name: setting_name_str,
+        value: value
+      })
+      |> Repo.insert(
+        # MySQL: ON DUPLICATE KEY UPDATE value = VALUES(value). MySQL triggers
+        # this on any unique-key conflict, so no conflict_target is given.
+        on_conflict: [set: [value: value]]
+      )
 
     # Invalidate cache on successful update
     case result do

--- a/lib/authify_web/controllers/maintenance_controller.ex
+++ b/lib/authify_web/controllers/maintenance_controller.ex
@@ -26,8 +26,7 @@ defmodule AuthifyWeb.MaintenanceController do
     maintenance_data = %{
       database_stats: get_database_stats(),
       system_health: get_system_health(),
-      cleanup_stats: get_cleanup_stats(),
-      maintenance_logs: get_recent_maintenance_logs()
+      cleanup_stats: get_cleanup_stats()
     }
 
     render(conn, :index,
@@ -110,7 +109,6 @@ defmodule AuthifyWeb.MaintenanceController do
       run_queue_length: get_run_queue_length(),
       process_count: :erlang.system_info(:process_count),
       active_connections: get_active_connections(),
-      last_backup: get_last_backup_time(),
       pending_jobs: get_pending_jobs_count()
     }
   end
@@ -122,35 +120,8 @@ defmodule AuthifyWeb.MaintenanceController do
       expired_invitations: Invitations.count_expired_invitations(),
       cleanable_invitations: Invitations.count_cleanable_invitations(),
       inactive_organizations_90d:
-        Stats.count_inactive_organizations_since(DateTime.add(now, -90, :day)),
-      orphaned_sessions: get_orphaned_sessions_count(),
-      temp_files: get_temp_files_count()
+        Stats.count_inactive_organizations_since(DateTime.add(now, -90, :day))
     }
-  end
-
-  defp get_recent_maintenance_logs do
-    # This would typically come from a maintenance_logs table
-    # For now, return placeholder data
-    [
-      %{
-        action: "Cleanup expired invitations",
-        timestamp: DateTime.add(DateTime.utc_now(), -2, :hour),
-        status: "completed",
-        details: "Removed 15 expired invitations"
-      },
-      %{
-        action: "Database optimization",
-        timestamp: DateTime.add(DateTime.utc_now(), -1, :day),
-        status: "completed",
-        details: "Optimized user and organization indexes"
-      },
-      %{
-        action: "Backup verification",
-        timestamp: DateTime.add(DateTime.utc_now(), -2, :day),
-        status: "completed",
-        details: "All backups verified successfully"
-      }
-    ]
   end
 
   # Placeholder functions for system metrics
@@ -195,11 +166,6 @@ defmodule AuthifyWeb.MaintenanceController do
     # of concurrent DB connections the application is provisioned to use.
     Application.get_env(:authify, Authify.Repo, [])
     |> Keyword.get(:pool_size, 1)
-  end
-
-  defp get_last_backup_time do
-    # Placeholder - would check actual backup system
-    DateTime.add(DateTime.utc_now(), -6, :hour)
   end
 
   defp get_pending_jobs_count do
@@ -266,15 +232,5 @@ defmodule AuthifyWeb.MaintenanceController do
       _ ->
         :error
     end
-  end
-
-  defp get_orphaned_sessions_count do
-    # Placeholder - would check for sessions without valid users
-    7
-  end
-
-  defp get_temp_files_count do
-    # Placeholder - would check temporary file storage
-    23
   end
 end

--- a/lib/authify_web/controllers/maintenance_controller.ex
+++ b/lib/authify_web/controllers/maintenance_controller.ex
@@ -104,8 +104,11 @@ defmodule AuthifyWeb.MaintenanceController do
 
   defp get_system_health do
     %{
-      uptime_seconds: :erlang.statistics(:wall_clock) |> elem(0) |> div(1000),
+      uptime_seconds: get_vm_uptime_seconds(),
       memory_usage: get_memory_usage(),
+      schedulers_online: System.schedulers_online(),
+      run_queue_length: get_run_queue_length(),
+      process_count: :erlang.system_info(:process_count),
       active_connections: get_active_connections(),
       last_backup: get_last_backup_time(),
       pending_jobs: get_pending_jobs_count()
@@ -154,31 +157,44 @@ defmodule AuthifyWeb.MaintenanceController do
   # These would typically interface with system monitoring tools
 
   defp get_database_size do
-    # Placeholder - would query actual database size
-    256.7
+    # Query the actual MySQL database size in MB.
+    case query_database_size() do
+      {:ok, bytes} -> round(bytes / 1024 / 1024 * 10) / 10
+      _ -> 0.0
+    end
   end
 
   defp get_table_sizes do
-    %{
-      "users" => 45.2,
-      "organizations" => 12.8,
-      "invitations" => 8.5,
-      "other" => 190.2
-    }
+    # Query actual per-table sizes from MySQL's information_schema.
+    case query_table_sizes() do
+      {:ok, rows} -> rows
+      _ -> %{}
+    end
   end
 
   defp get_memory_usage do
-    # Placeholder - would query actual memory usage
+    memory = :erlang.memory()
+
+    # Total = all BEAM memory (not system-wide). We report BEAM VM memory here.
+    total_bytes = memory[:total]
+    used_bytes = total_bytes - memory[:system]
+    available_bytes = memory[:processes_used] + memory[:system]
+
     %{
-      total_mb: 1024,
-      used_mb: 768,
-      available_mb: 256
+      total_bytes: total_bytes,
+      used_bytes: used_bytes,
+      available_bytes: available_bytes,
+      total_mb: div(total_bytes, 1024 * 1024),
+      used_mb: div(used_bytes, 1024 * 1024),
+      available_mb: div(available_bytes, 1024 * 1024)
     }
   end
 
   defp get_active_connections do
-    # Placeholder - would query actual database connections
-    12
+    # Report the configured database connection pool size, which is the number
+    # of concurrent DB connections the application is provisioned to use.
+    Application.get_env(:authify, Authify.Repo, [])
+    |> Keyword.get(:pool_size, 1)
   end
 
   defp get_last_backup_time do
@@ -187,8 +203,69 @@ defmodule AuthifyWeb.MaintenanceController do
   end
 
   defp get_pending_jobs_count do
-    # Placeholder - would check job queue
-    3
+    # Count Oban jobs in non-terminal states (queued for execution).
+    import Ecto.Query
+
+    from(j in Oban.Job,
+      where: j.state in ["available", "scheduled", "retryable", "executing", "waiting"]
+    )
+    |> Authify.Repo.aggregate(:count, :id)
+  end
+
+  # VM metrics
+
+  defp get_vm_uptime_seconds do
+    :erlang.statistics(:wall_clock) |> elem(0) |> div(1000)
+  end
+
+  defp get_run_queue_length do
+    :erlang.statistics(:total_run_queue_lengths_all)
+  end
+
+  defp query_database_size do
+    query = """
+    SELECT SUM(data_length + index_length) AS bytes
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+    """
+
+    case Authify.Repo.query(query) do
+      {:ok, %{rows: [[nil]]}} ->
+        {:ok, 0}
+
+      {:ok, %{rows: [[bytes]]}} when is_integer(bytes) ->
+        {:ok, bytes}
+
+      {:ok, %{rows: [[bytes]]}} when is_binary(bytes) ->
+        {:ok, String.to_integer(bytes)}
+
+      _ ->
+        :error
+    end
+  end
+
+  defp query_table_sizes do
+    query = """
+    SELECT table_name, (data_length + index_length) AS bytes
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+    ORDER BY bytes DESC
+    LIMIT 10
+    """
+
+    case Authify.Repo.query(query) do
+      {:ok, %{rows: rows}} ->
+        sizes =
+          Enum.reduce(rows, %{}, fn [table, bytes], acc ->
+            bytes = if is_binary(bytes), do: String.to_integer(bytes), else: bytes
+            Map.put(acc, table, round(bytes / 1024 / 1024 * 10) / 10)
+          end)
+
+        {:ok, sizes}
+
+      _ ->
+        :error
+    end
   end
 
   defp get_orphaned_sessions_count do

--- a/lib/authify_web/controllers/maintenance_html.ex
+++ b/lib/authify_web/controllers/maintenance_html.ex
@@ -18,9 +18,4 @@ defmodule AuthifyWeb.MaintenanceHTML do
   end
 
   def format_memory_percentage(_, _), do: "N/A"
-
-  def status_badge_class("completed"), do: "bg-success"
-  def status_badge_class("running"), do: "bg-primary"
-  def status_badge_class("failed"), do: "bg-danger"
-  def status_badge_class(_), do: "bg-secondary"
 end

--- a/lib/authify_web/controllers/maintenance_html/index.html.heex
+++ b/lib/authify_web/controllers/maintenance_html/index.html.heex
@@ -53,7 +53,7 @@
                         <div class="fw-bold fs-5">
                           {@maintenance.system_health.memory_usage.used_mb} MB
                         </div>
-                        <div class="small">Memory Used</div>
+                        <div class="small">BEAM Memory Used</div>
                         <div class="small">
                           ({format_memory_percentage(
                             @maintenance.system_health.memory_usage.used_mb,
@@ -368,6 +368,16 @@
                   )}
                   <span class="badge bg-success ms-2">Up to date</span>
                 </p>
+
+                <h6 class="text-muted">BEAM VM</h6>
+                <dl class="row mb-3 small">
+                  <dt class="col-6">Schedulers</dt>
+                  <dd class="col-6">{@maintenance.system_health.schedulers_online}</dd>
+                  <dt class="col-6">Run Queue Length</dt>
+                  <dd class="col-6">{@maintenance.system_health.run_queue_length}</dd>
+                  <dt class="col-6">Processes</dt>
+                  <dd class="col-6">{@maintenance.system_health.process_count}</dd>
+                </dl>
 
                 <h6 class="text-muted">Memory Details</h6>
                 <div class="progress mb-2" style="height: 20px;">

--- a/lib/authify_web/controllers/maintenance_html/index.html.heex
+++ b/lib/authify_web/controllers/maintenance_html/index.html.heex
@@ -190,22 +190,6 @@
                 </div>
               </div>
             </div>
-            <div class="row g-3">
-              <div class="col-6">
-                <div class="text-center">
-                  <div class="h5 text-secondary">
-                    {@maintenance.cleanup_stats.orphaned_sessions}
-                  </div>
-                  <div class="small text-muted">Orphaned Sessions</div>
-                </div>
-              </div>
-              <div class="col-6">
-                <div class="text-center">
-                  <div class="h5 text-info">{@maintenance.cleanup_stats.temp_files}</div>
-                  <div class="small text-muted">Temp Files</div>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </div>
@@ -298,56 +282,6 @@
       </div>
     </div>
 
-    <!-- Recent Maintenance Logs -->
-    <div class="row">
-      <div class="col-12">
-        <div class="card">
-          <div class="card-header">
-            <h5 class="card-title mb-0">
-              <i class="bi bi-journal-text"></i> Recent Maintenance Activity
-            </h5>
-          </div>
-          <div class="card-body">
-            <%= if length(@maintenance.maintenance_logs) > 0 do %>
-              <div class="table-responsive">
-                <table class="table table-hover">
-                  <thead>
-                    <tr>
-                      <th>Action</th>
-                      <th>Status</th>
-                      <th>Details</th>
-                      <th>Timestamp</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <%= for log <- @maintenance.maintenance_logs do %>
-                      <tr>
-                        <td>{log.action}</td>
-                        <td>
-                          <span class={"badge #{status_badge_class(log.status)}"}>
-                            {String.capitalize(log.status)}
-                          </span>
-                        </td>
-                        <td class="text-muted small">{log.details}</td>
-                        <td class="text-muted small">
-                          {Calendar.strftime(log.timestamp, "%B %d, %Y at %I:%M %p")}
-                        </td>
-                      </tr>
-                    <% end %>
-                  </tbody>
-                </table>
-              </div>
-            <% else %>
-              <div class="text-center text-muted py-4">
-                <i class="bi bi-journal fs-1 mb-2"></i>
-                <p>No recent maintenance activity</p>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    </div>
-
     <!-- System Information -->
     <div class="row mt-4">
       <div class="col-12">
@@ -360,15 +294,6 @@
           <div class="card-body">
             <div class="row">
               <div class="col-md-6">
-                <h6 class="text-muted">Backup Status</h6>
-                <p class="mb-3">
-                  Last backup: {Calendar.strftime(
-                    @maintenance.system_health.last_backup,
-                    "%B %d, %Y at %I:%M %p"
-                  )}
-                  <span class="badge bg-success ms-2">Up to date</span>
-                </p>
-
                 <h6 class="text-muted">BEAM VM</h6>
                 <dl class="row mb-3 small">
                   <dt class="col-6">Schedulers</dt>
@@ -408,7 +333,6 @@
                   <li>Monitor inactive organizations monthly</li>
                   <li>Recalculate statistics after major data changes</li>
                   <li>Keep system memory usage below 80%</li>
-                  <li>Ensure database backups are running daily</li>
                 </ul>
               </div>
             </div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.19.0",
+      version: "0.19.1",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
+++ b/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
@@ -1,0 +1,57 @@
+defmodule Authify.Repo.Migrations.SeedTenantBaseDomain do
+  use Ecto.Migration
+  import Ecto.Query
+
+  @default_domain "authify.test"
+
+  def up do
+    global_org_id =
+      repo().one(
+        from(o in "organizations",
+          where: o.slug == "authify-global",
+          select: o.id
+        )
+      )
+
+    if global_org_id do
+      config_id =
+        repo().one(
+          from(c in "configurations",
+            where:
+              c.configurable_type == "Organization" and
+                c.configurable_id == ^global_org_id,
+            select: c.id
+          )
+        )
+
+      if config_id do
+        # Only insert if the setting doesn't already exist
+        existing =
+          repo().one(
+            from(cv in "configuration_values",
+              where:
+                cv.configuration_id == ^config_id and
+                  cv.setting_name == "tenant_base_domain",
+              select: cv.id
+            )
+          )
+
+        unless existing do
+          repo().insert_all("configuration_values", [
+            %{
+              configuration_id: config_id,
+              setting_name: "tenant_base_domain",
+              value: @default_domain,
+              inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
+              updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+            }
+          ])
+        end
+      end
+    end
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
+++ b/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
@@ -2,9 +2,26 @@ defmodule Authify.Repo.Migrations.SeedTenantBaseDomain do
   use Ecto.Migration
   import Ecto.Query
 
-  @default_domain "authify.test"
+  # Seed a default tenant_base_domain for the test environment only. This
+  # eliminates the deadlock (1213) that occurred when many async tests each
+  # wrote tenant_base_domain in their setup — concurrent INSERTs to the same
+  # unique key gap-locked in MySQL. By pre-seeding the row, tests inherit it
+  # from the migrated DB state and never need to write it.
+  #
+  # In production, this migration is a no-op — the guided setup process
+  # provides the tenant_base_domain, and we don't want to pollute it with
+  # a test-only default.
+  @test_domain "authify.test"
 
   def up do
+    unless Mix.env() == :test do
+      :ok
+    else
+      seed_tenant_base_domain()
+    end
+  end
+
+  defp seed_tenant_base_domain do
     global_org_id =
       repo().one(
         from(o in "organizations",
@@ -25,7 +42,6 @@ defmodule Authify.Repo.Migrations.SeedTenantBaseDomain do
         )
 
       if config_id do
-        # Only insert if the setting doesn't already exist
         existing =
           repo().one(
             from(cv in "configuration_values",
@@ -37,13 +53,15 @@ defmodule Authify.Repo.Migrations.SeedTenantBaseDomain do
           )
 
         unless existing do
+          now = DateTime.truncate(DateTime.utc_now(), :second)
+
           repo().insert_all("configuration_values", [
             %{
               configuration_id: config_id,
               setting_name: "tenant_base_domain",
-              value: @default_domain,
-              inserted_at: DateTime.truncate(DateTime.utc_now(), :second),
-              updated_at: DateTime.truncate(DateTime.utc_now(), :second)
+              value: @test_domain,
+              inserted_at: now,
+              updated_at: now
             }
           ])
         end

--- a/test/authify/configurations/domain_settings_test.exs
+++ b/test/authify/configurations/domain_settings_test.exs
@@ -6,12 +6,6 @@ defmodule Authify.Configurations.DomainSettingsTest do
 
   import Authify.AccountsFixtures
 
-  setup do
-    # Set required tenant_base_domain for all tests
-    Configurations.set_global_setting(:tenant_base_domain, "authify.test")
-    :ok
-  end
-
   describe "tenant_base_domain global setting" do
     test "can be set and retrieved" do
       assert {:ok, _} =

--- a/test/authify/organizations_test.exs
+++ b/test/authify/organizations_test.exs
@@ -6,12 +6,6 @@ defmodule Authify.OrganizationsTest do
   alias Authify.Organizations.OrganizationCname
   import Authify.AccountsFixtures
 
-  setup do
-    # Set required tenant_base_domain for all tests
-    Configurations.set_global_setting(:tenant_base_domain, "authify.test")
-    :ok
-  end
-
   describe "list_organization_cnames/1" do
     test "returns all CNAMEs for an organization" do
       org = organization_fixture()


### PR DESCRIPTION
## Root cause

Multiple async tests called `set_global_setting(:tenant_base_domain, "authify.test")` in their `setup` blocks. Every concurrent test wrote to the **same global `configuration_values` row** — the same unique `(configuration_id, setting_name)` key. MySQL's InnoDB gap-locked the unique index during concurrent `INSERT ... ON DUPLICATE KEY UPDATE`, causing deadlock (1213).

## Fix

A new migration (`20260824000000_seed_tenant_base_domain.exs`) seeds the default `tenant_base_domain = "authify.test"` — **test environment only** (`Mix.env() == :test`). In dev/prod it's a no-op, so the guided setup process is unaffected. Tests inherit the value from the migrated DB state instead of writing it themselves, eliminating the concurrent-write contention.

## Also included

- **Atomic upsert** (`on_conflict`): `upsert_configuration_value/3` now uses a single `INSERT ... ON DUPLICATE KEY UPDATE` instead of check-then-insert, eliminating the TOCTOU race in production when two concurrent requests set the same config value.
- **Maintenance page**: replaced hardcoded placeholder data with real BEAM VM stats (memory, schedulers, run queue, process count), real MySQL database/table sizes, and real Oban pending job count. Removed placeholder "Backup Status", "Orphaned Sessions", "Temp Files", and "Recent Maintenance Activity" sections.
- **Version bump** to `0.19.1`.

## Verification

- No more `1213 Deadlock` errors across multiple full-suite runs (previously 1-5 failures per run).
- 4 of 5 runs completely clean (1965/1965). The rare remaining flake is a pre-existing `socket closed` pool-reaping issue, unrelated to deadlocks.