### PR TITLE
Fix production deploy: Mix.env/0 not available in releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-08-24
+
+### Fixed
+
+- Fixed production deploy crash: `Mix.env/0` is not available in releases, replaced with `Application.get_env(:authify, :env)` in the tenant_base_domain seed migration
+
 ## [0.19.1] - 2026-08-24
 
 ### Fixed
@@ -747,7 +753,8 @@ Initial release of Authify - Multi-tenant Identity Provider
 - Prometheus metrics with telemetry
 - Bandit web server
 
-[Unreleased]: https://github.com/authify/authify/compare/v0.19.1...HEAD
+[Unreleased]: https://github.com/authify/authify/compare/v0.19.2...HEAD
+[0.19.2]: https://github.com/authify/authify/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/authify/authify/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/authify/authify/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/authify/authify/compare/v0.12.3...v0.18.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.19.1",
+      version: "0.19.2",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
+++ b/priv/repo/migrations/20260824000000_seed_tenant_base_domain.exs
@@ -14,7 +14,9 @@ defmodule Authify.Repo.Migrations.SeedTenantBaseDomain do
   @test_domain "authify.test"
 
   def up do
-    unless Mix.env() == :test do
+    # Mix is not available in releases, so use the app env that each
+    # environment config sets (config/test.exs, config/prod.exs, etc.).
+    unless Application.get_env(:authify, :env) == :test do
       :ok
     else
       seed_tenant_base_domain()


### PR DESCRIPTION
## Problem

The tenant_base_domain seed migration used `Mix.env()`, which is not available in Elixir releases. This crashed the migrate step on production deploy:

```
** (UndefinedFunctionError) function Mix.env/0 is undefined (module Mix is not available)
```

## Fix

Replace `Mix.env()` with `Application.get_env(:authify, :env)`, which is set by each environment's config file (`config/test.exs`, `config/prod.exs`, etc.) and is available in releases.

## Verification

- Test env: migration seeds `tenant_base_domain = "authify.test"` ✓
- Dev env: migration is a no-op ✓
- Full test suite: 1965 passed, 1 skipped ✓

Version bumped to `0.19.2`.