### PR TITLE
Support client_secret_basic authentication on token endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-08-26
+
+### Fixed
+
+- Token endpoint now supports `client_secret_basic` authentication (RFC 6749 §2.3.1). Client credentials are read from the `Authorization: Basic` header in addition to the form body, fixing a 500 error for OIDC clients (e.g. Spring Security) that default to Basic auth
+
 ## [0.19.2] - 2026-08-24
 
 ### Fixed
@@ -752,8 +758,9 @@ Initial release of Authify - Multi-tenant Identity Provider
 - Req for HTTP client operations
 - Prometheus metrics with telemetry
 - Bandit web server
+[Unreleased]: https://github.com/authify/authify/compare/v0.19.3...HEAD
 
-[Unreleased]: https://github.com/authify/authify/compare/v0.19.2...HEAD
+[0.19.3]: https://github.com/authify/authify/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/authify/authify/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/authify/authify/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/authify/authify/compare/v0.18.0...v0.19.0

--- a/lib/authify_web/controllers/oauth_controller.ex
+++ b/lib/authify_web/controllers/oauth_controller.ex
@@ -196,6 +196,8 @@ defmodule AuthifyWeb.OAuthController do
   Supports grant types: authorization_code, refresh_token, client_credentials.
   """
   def token(conn, params) do
+    params = extract_client_credentials(conn, params)
+
     case params["grant_type"] do
       "authorization_code" ->
         handle_authorization_code_grant(conn, params)
@@ -212,6 +214,26 @@ defmodule AuthifyWeb.OAuthController do
           error_description:
             "Supported grant types: authorization_code, refresh_token, client_credentials"
         })
+    end
+  end
+
+  defp extract_client_credentials(conn, params) do
+    case get_req_header(conn, "authorization") do
+      ["Basic " <> encoded | _] ->
+        case Base.decode64(encoded) do
+          {:ok, decoded} ->
+            [client_id, client_secret] = String.split(decoded, ":", parts: 2)
+
+            params
+            |> Map.put_new("client_id", client_id)
+            |> Map.put_new("client_secret", client_secret)
+
+          _ ->
+            params
+        end
+
+      _ ->
+        params
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.19.2",
+      version: "0.19.3",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/authify_web/controllers/oauth_controller_test.exs
+++ b/test/authify_web/controllers/oauth_controller_test.exs
@@ -247,6 +247,49 @@ defmodule AuthifyWeb.OAuthControllerTest do
       assert response["id_token"]
     end
 
+    test "exchanges valid authorization code for access token using client_secret_basic", %{
+      conn: conn,
+      application: application,
+      auth_code: auth_code,
+      organization: organization
+    } do
+      basic =
+        Base.encode64("#{application.client_id}:#{application.client_secret}")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> basic)
+        |> post(~p"/#{organization.slug}/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => auth_code.code
+        })
+
+      response = json_response(conn, 200)
+
+      assert response["access_token"]
+      assert response["token_type"] == "Bearer"
+      assert response["id_token"]
+    end
+
+    test "returns invalid_client when Basic header credentials are invalid", %{
+      conn: conn,
+      auth_code: auth_code,
+      organization: organization
+    } do
+      basic = Base.encode64("invalid_client:invalid_secret")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> basic)
+        |> post(~p"/#{organization.slug}/oauth/token", %{
+          "grant_type" => "authorization_code",
+          "code" => auth_code.code
+        })
+
+      response = json_response(conn, 401)
+      assert response["error"] == "invalid_client"
+    end
+
     test "returns error for invalid authorization code", %{
       conn: conn,
       application: application,
@@ -369,6 +412,45 @@ defmodule AuthifyWeb.OAuthControllerTest do
       assert response["scope"] == "management_app:read users:read"
       # Should NOT include ID token for client credentials
       refute response["id_token"]
+    end
+
+    test "exchanges client credentials for token using client_secret_basic", %{
+      conn: conn,
+      application: application,
+      organization: organization
+    } do
+      basic = Base.encode64("#{application.client_id}:#{application.client_secret}")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> basic)
+        |> post(~p"/#{organization.slug}/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "scope" => "management_app:read users:read"
+        })
+
+      response = json_response(conn, 200)
+
+      assert response["access_token"]
+      assert response["token_type"] == "Bearer"
+      assert response["scope"] == "management_app:read users:read"
+    end
+
+    test "returns invalid_client when Basic header credentials are invalid", %{
+      conn: conn,
+      organization: organization
+    } do
+      basic = Base.encode64("invalid_client:invalid_secret")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> basic)
+        |> post(~p"/#{organization.slug}/oauth/token", %{
+          "grant_type" => "client_credentials"
+        })
+
+      response = json_response(conn, 401)
+      assert response["error"] == "invalid_client"
     end
 
     test "returns all granted scopes when scope parameter is omitted", %{
@@ -1116,6 +1198,39 @@ defmodule AuthifyWeb.OAuthControllerTest do
         |> Jason.decode!()
 
       assert header_json["alg"] == "RS256"
+    end
+
+    test "refresh token grant exchanges with client_secret_basic", %{
+      conn: conn,
+      application: application,
+      user: user,
+      organization: organization
+    } do
+      {:ok, auth_code} =
+        Authify.OAuth.create_authorization_code(
+          application,
+          user,
+          "https://example.com/callback",
+          ["openid", "profile"]
+        )
+
+      {:ok, result} = Authify.OAuth.exchange_authorization_code(auth_code, application)
+      refresh_token = result.refresh_token
+
+      basic = Base.encode64("#{application.client_id}:#{application.client_secret}")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> basic)
+        |> post(~p"/#{organization.slug}/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh_token.plaintext_token
+        })
+
+      response = json_response(conn, 200)
+
+      assert response["access_token"]
+      assert response["refresh_token"]
     end
 
     test "userinfo endpoint returns proper OIDC claims", %{


### PR DESCRIPTION
Fixes #199

## Summary

The OIDC discovery document advertises `client_secret_basic` as a supported token endpoint authentication method, but the token endpoint only read client credentials from the form body (`client_secret_post`). OIDC clients that default to `client_secret_basic` (e.g. Spring Security) would hit a 500 instead of a proper token response.

This PR makes the token endpoint read client credentials from the `Authorization: Basic` header in addition to the form body, per [RFC 6749 §2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1). When both are present, form-body params take precedence.

Applies to all three grant types (`authorization_code`, `refresh_token`, `client_credentials`).

## Changes

- `lib/authify_web/controllers/oauth_controller.ex`: Added `extract_client_credentials/2`, called at the top of `token/2`, which base64-decodes `client_id:client_secret` from the Basic header and merges them into params via `Map.put_new/3`.
- `test/authify_web/controllers/oauth_controller_test.exs`: Added tests for `client_secret_basic` success and invalid-credential (401) paths across `authorization_code`, `refresh_token`, and `client_credentials` grants.

## Verification

- `mix precommit`: 1969 passed, 1 skipped; credo & sobelow clean