### PR TITLE
Make password complexity requirements configurable per organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-26
+
+### Added
+
+- Per-organization password complexity policy. Organization admins can now configure the password requirements (minimum/maximum length, required uppercase/lowercase/digit/special character classes, and the common-password blocklist) via the Configuration settings page. The previous strict rules remain the default so existing organizations see no change until they opt in
+- Password validation (registration, admin user creation, self-service change, password reset, invitation acceptance, and SCIM provisioning) now resolves the effective policy for the organization
+- SCIM-generated passwords now satisfy the organization's configured policy
+- Password hint text in the UI (Add User, Accept Invitation, Change Password, Password Reset, Create Organization) reflects the organization's effective policy
+
 ## [0.19.3] - 2026-08-26
 
 ### Fixed
@@ -758,8 +767,9 @@ Initial release of Authify - Multi-tenant Identity Provider
 - Req for HTTP client operations
 - Prometheus metrics with telemetry
 - Bandit web server
-[Unreleased]: https://github.com/authify/authify/compare/v0.19.3...HEAD
+[Unreleased]: https://github.com/authify/authify/compare/v0.20.0...HEAD
 
+[0.20.0]: https://github.com/authify/authify/compare/v0.19.3...v0.20.0
 [0.19.3]: https://github.com/authify/authify/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/authify/authify/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/authify/authify/compare/v0.19.0...v0.19.1

--- a/lib/authify/accounts.ex
+++ b/lib/authify/accounts.ex
@@ -266,8 +266,10 @@ defmodule Authify.Accounts do
         default_primary: true
       )
 
+    policy = resolve_password_policy_from_attrs(normalized_attrs)
+
     %User{}
-    |> User.registration_changeset(normalized_attrs)
+    |> User.registration_changeset(normalized_attrs, policy)
     |> Repo.insert()
   end
 
@@ -361,7 +363,7 @@ defmodule Authify.Accounts do
   Returns an `%Ecto.Changeset{}` for user registration.
   """
   def change_user_registration(%User{} = user, attrs \\ %{}) do
-    User.registration_changeset(user, attrs)
+    User.registration_changeset(user, attrs, resolve_password_policy_from_attrs(attrs))
   end
 
   @doc """
@@ -1069,7 +1071,7 @@ defmodule Authify.Accounts do
   Change user password changeset.
   """
   def change_user_password(user) do
-    User.password_changeset(user, %{})
+    User.password_changeset(user, %{}, resolve_password_policy_for_user(user))
   end
 
   @doc """
@@ -1077,7 +1079,7 @@ defmodule Authify.Accounts do
   """
   def update_user_password(user, attrs) do
     user
-    |> User.password_changeset(attrs)
+    |> User.password_changeset(attrs, resolve_password_policy_for_user(user))
     |> Repo.update()
   end
 
@@ -1160,7 +1162,12 @@ defmodule Authify.Accounts do
              DateTime.compare(user.password_reset_expires_at, DateTime.utc_now()) == :lt do
           {:error, :token_expired}
         else
-          changeset = User.password_reset_completion_changeset(user, password_params)
+          changeset =
+            User.password_reset_completion_changeset(
+              user,
+              password_params,
+              resolve_password_policy_for_user(user)
+            )
 
           case Repo.update(changeset) do
             {:ok, updated_user} -> {:ok, updated_user}
@@ -1319,7 +1326,7 @@ defmodule Authify.Accounts do
   Change user password with 2 params.
   """
   def change_user_password(user, attrs) do
-    User.password_changeset(user, attrs)
+    User.password_changeset(user, attrs, resolve_password_policy_for_user(user))
   end
 
   @doc """
@@ -1353,4 +1360,25 @@ defmodule Authify.Accounts do
     |> Repo.delete_all()
     |> elem(0)
   end
+
+  # Resolves the effective password policy from user creation attrs, using the
+  # organization_id when present, otherwise the global default.
+  defp resolve_password_policy_from_attrs(attrs) do
+    case Map.get(attrs, "organization_id") || Map.get(attrs, :organization_id) do
+      nil -> Authify.PasswordPolicy.default_policy()
+      organization_id -> Authify.PasswordPolicy.resolve(organization_id)
+    end
+  end
+
+  # Resolves the effective password policy for a user's organization.
+  defp resolve_password_policy_for_user(%User{organization: %Organization{} = org}) do
+    Authify.PasswordPolicy.resolve(org)
+  end
+
+  defp resolve_password_policy_for_user(%User{organization_id: organization_id})
+       when not is_nil(organization_id) do
+    Authify.PasswordPolicy.resolve(organization_id)
+  end
+
+  defp resolve_password_policy_for_user(%User{}), do: Authify.PasswordPolicy.default_policy()
 end

--- a/lib/authify/accounts/user.ex
+++ b/lib/authify/accounts/user.ex
@@ -114,11 +114,15 @@ defmodule Authify.Accounts.User do
 
   @doc false
   def changeset(user, attrs) do
+    changeset(user, attrs, Authify.PasswordPolicy.default_policy())
+  end
+
+  def changeset(user, attrs, policy) do
     user
     |> cast(attrs, @optional_fields ++ @password_fields)
     |> validate_username()
     |> validate_role()
-    |> validate_password()
+    |> validate_password(policy)
     |> validate_theme_preference()
     |> validate_external_id()
     |> validate_url_field(:avatar_url)
@@ -135,8 +139,12 @@ defmodule Authify.Accounts.User do
   Requires at least one email address with primary=true.
   """
   def registration_changeset(user, attrs) do
+    registration_changeset(user, attrs, Authify.PasswordPolicy.default_policy())
+  end
+
+  def registration_changeset(user, attrs, policy) do
     user
-    |> changeset(attrs)
+    |> changeset(attrs, policy)
     |> cast_assoc(:emails, required: true, with: &UserEmail.nested_changeset/2)
     |> validate_has_primary_email()
     |> validate_required([:password])
@@ -158,9 +166,13 @@ defmodule Authify.Accounts.User do
 
   @doc false
   def password_changeset(user, attrs) do
+    password_changeset(user, attrs, Authify.PasswordPolicy.default_policy())
+  end
+
+  def password_changeset(user, attrs, policy) do
     user
     |> cast(attrs, @password_fields)
-    |> validate_password()
+    |> validate_password(policy)
     |> put_password_hash()
   end
 
@@ -326,108 +338,12 @@ defmodule Authify.Accounts.User do
     end
   end
 
-  defp validate_password(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+  defp validate_password(%Ecto.Changeset{valid?: false} = changeset, _policy), do: changeset
 
-  defp validate_password(changeset) do
+  defp validate_password(changeset, policy) do
     changeset
-    |> validate_length(:password,
-      min: 8,
-      max: 100,
-      message: "must be between 8 and 100 characters"
-    )
+    |> Authify.PasswordPolicy.validate_password(policy)
     |> validate_confirmation(:password, message: "does not match password")
-    |> validate_password_complexity()
-  end
-
-  defp validate_password_complexity(changeset) do
-    case get_change(changeset, :password) do
-      nil ->
-        changeset
-
-      password when is_binary(password) ->
-        changeset
-        |> validate_password_has_uppercase(password)
-        |> validate_password_has_lowercase(password)
-        |> validate_password_has_digit(password)
-        |> validate_password_has_special_char(password)
-        |> validate_password_not_common(password)
-
-      _ ->
-        changeset
-    end
-  end
-
-  defp validate_password_has_uppercase(changeset, password) do
-    if Regex.match?(~r/[A-Z]/, password) do
-      changeset
-    else
-      add_error(changeset, :password, "must contain at least one uppercase letter")
-    end
-  end
-
-  defp validate_password_has_lowercase(changeset, password) do
-    if Regex.match?(~r/[a-z]/, password) do
-      changeset
-    else
-      add_error(changeset, :password, "must contain at least one lowercase letter")
-    end
-  end
-
-  defp validate_password_has_digit(changeset, password) do
-    if Regex.match?(~r/[0-9]/, password) do
-      changeset
-    else
-      add_error(changeset, :password, "must contain at least one number")
-    end
-  end
-
-  defp validate_password_has_special_char(changeset, password) do
-    if Regex.match?(~r/[^A-Za-z0-9]/, password) do
-      changeset
-    else
-      add_error(
-        changeset,
-        :password,
-        "must contain at least one special character (!@#$%^&*()_+-=[]{}|;:,.<>?)"
-      )
-    end
-  end
-
-  defp validate_password_not_common(changeset, password) do
-    # List of common passwords to reject
-    common_passwords = [
-      "password",
-      "123456",
-      "12345678",
-      "qwerty",
-      "abc123",
-      "password123",
-      "admin",
-      "letmein",
-      "welcome",
-      "monkey",
-      "1234567890",
-      "password1",
-      "123456789",
-      "welcome123",
-      "admin123",
-      "root",
-      "toor",
-      "pass",
-      "test",
-      "guest",
-      "user",
-      "demo",
-      "temp",
-      "changeme",
-      "default"
-    ]
-
-    if String.downcase(password) in common_passwords do
-      add_error(changeset, :password, "is too common, please choose a more secure password")
-    else
-      changeset
-    end
   end
 
   defp validate_url_field(changeset, field) do
@@ -708,8 +624,12 @@ defmodule Authify.Accounts.User do
   Returns a changeset for password reset completion.
   """
   def password_reset_completion_changeset(%__MODULE__{} = user, attrs) do
+    password_reset_completion_changeset(user, attrs, Authify.PasswordPolicy.default_policy())
+  end
+
+  def password_reset_completion_changeset(%__MODULE__{} = user, attrs, policy) do
     user
-    |> password_changeset(attrs)
+    |> password_changeset(attrs, policy)
     |> Ecto.Changeset.put_change(:password_reset_token, nil)
     |> Ecto.Changeset.put_change(:password_reset_expires_at, nil)
   end

--- a/lib/authify/configurations/schemas/organization.ex
+++ b/lib/authify/configurations/schemas/organization.ex
@@ -14,228 +14,250 @@ defmodule Authify.Configurations.Schemas.Organization do
   def settings do
     rate_limit_quota_settings() ++
       rate_limit_settings() ++
-      [
-        # Feature toggles
-        %{
-          name: :allow_invitations,
-          description: "Allow organization admins to invite new users",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :allow_saml,
-          description: "Enable SAML identity provider functionality for this organization",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :allow_oauth,
-          description: "Enable OAuth2/OIDC identity provider functionality for this organization",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :oauth_21_strict_mode,
-          description:
-            "Enable strict OAuth 2.1 compliance mode. When enabled, PKCE is required for all " <>
-              "authorization code flow clients (including confidential clients). Defaults to " <>
-              "false for backwards compatibility.",
-          value_type: :boolean,
-          default_value: false,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :allow_webauthn,
-          description:
-            "Enable WebAuthn/FIDO2 authentication (security keys, passkeys, biometrics) for this organization",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :sign_audit_logs,
-          description:
-            "Cryptographically sign audit log events with the organization's audit signing " <>
-              "certificate for compliance verification. When enabled, each new audit event is " <>
-              "signed with RSA-SHA256; the signature and a link to the public certificate are " <>
-              "included in API responses.",
-          value_type: :boolean,
-          default_value: false,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :scim_inbound_provisioning_enabled,
-          description:
-            "Enable SCIM 2.0 Service Provider endpoints - allows external identity providers and HR systems to provision users and groups into this organization",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :scim_outbound_provisioning_enabled,
-          description:
-            "Enable SCIM 2.0 outbound provisioning - automatically provision users and groups to configured SCIM clients (downstream applications)",
-          value_type: :boolean,
-          default_value: false,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :scim_client_request_delay_ms,
-          description:
-            "Minimum delay in milliseconds between consecutive SCIM outbound requests to the same provider. Higher values reduce load on downstream systems. Must be between 50ms and 5000ms.",
-          value_type: :integer,
-          default_value: 100,
-          required: false,
-          validation_fn: &validate_scim_request_delay/1
-        },
-        # MFA (Multi-Factor Authentication) settings
-        %{
-          name: :require_mfa,
-          description:
-            "Require all users in this organization to enable multi-factor authentication",
-          value_type: :boolean,
-          default_value: false,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :mfa_lockout_enabled,
-          description: "Enable account lockout after failed MFA verification attempts",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :mfa_lockout_attempts,
-          description: "Number of failed MFA attempts before account lockout (1-10)",
-          value_type: :integer,
-          default_value: 5,
-          required: false,
-          validation_fn: &validate_mfa_attempts/1
-        },
-        %{
-          name: :mfa_lockout_duration_minutes,
-          description: "Duration of MFA lockout in minutes (1-60)",
-          value_type: :integer,
-          default_value: 5,
-          required: false,
-          validation_fn: &validate_lockout_duration/1
-        },
-        # Profile/branding fields
-        %{
-          name: :description,
-          description: "Organization description",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_description/1
-        },
-        %{
-          name: :website_url,
-          description: "Organization website URL",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_url/1
-        },
-        %{
-          name: :contact_email,
-          description: "Organization contact email",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_email/1
-        },
-        %{
-          name: :logo_url,
-          description: "Organization logo URL",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_url/1
-        },
-        # Domain configuration
-        %{
-          name: :email_link_domain,
-          description:
-            "Domain used in email links (invitations, password reset, etc.). Must be either the organization's subdomain or one of its configured CNAMEs.",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: nil
-        },
-        # SMTP configuration
-        %{
-          name: :smtp_server,
-          description: "SMTP server hostname (e.g., smtp.gmail.com)",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_smtp_server/1
-        },
-        %{
-          name: :smtp_port,
-          description:
-            "SMTP server port (typically 587 for TLS, 465 for SSL, 25 for unencrypted)",
-          value_type: :integer,
-          default_value: 587,
-          required: false,
-          validation_fn: &validate_smtp_port/1
-        },
-        %{
-          name: :smtp_username,
-          description: "SMTP authentication username",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :smtp_password,
-          description: "SMTP authentication password",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: nil,
-          encrypted: true
-        },
-        %{
-          name: :smtp_from_email,
-          description: "Email address to use in the 'From' field",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: &validate_email/1
-        },
-        %{
-          name: :smtp_from_name,
-          description: "Name to use in the 'From' field (e.g., 'Acme Corp')",
-          value_type: :string,
-          default_value: nil,
-          required: false,
-          validation_fn: nil
-        },
-        %{
-          name: :smtp_use_ssl,
-          description: "Use SSL/TLS for SMTP connection",
-          value_type: :boolean,
-          default_value: true,
-          required: false,
-          validation_fn: nil
-        }
-      ]
+      password_policy_settings() ++
+      feature_toggle_settings() ++
+      profile_settings() ++
+      domain_settings() ++
+      smtp_settings()
+  end
+
+  # Feature toggles
+  defp feature_toggle_settings do
+    [
+      %{
+        name: :allow_invitations,
+        description: "Allow organization admins to invite new users",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :allow_saml,
+        description: "Enable SAML identity provider functionality for this organization",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :allow_oauth,
+        description: "Enable OAuth2/OIDC identity provider functionality for this organization",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :oauth_21_strict_mode,
+        description:
+          "Enable strict OAuth 2.1 compliance mode. When enabled, PKCE is required for all " <>
+            "authorization code flow clients (including confidential clients). Defaults to " <>
+            "false for backwards compatibility.",
+        value_type: :boolean,
+        default_value: false,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :allow_webauthn,
+        description:
+          "Enable WebAuthn/FIDO2 authentication (security keys, passkeys, biometrics) for this organization",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :sign_audit_logs,
+        description:
+          "Cryptographically sign audit log events with the organization's audit signing " <>
+            "certificate for compliance verification. When enabled, each new audit event is " <>
+            "signed with RSA-SHA256; the signature and a link to the public certificate are " <>
+            "included in API responses.",
+        value_type: :boolean,
+        default_value: false,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :scim_inbound_provisioning_enabled,
+        description:
+          "Enable SCIM 2.0 Service Provider endpoints - allows external identity providers and HR systems to provision users and groups into this organization",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :scim_outbound_provisioning_enabled,
+        description:
+          "Enable SCIM 2.0 outbound provisioning - automatically provision users and groups to configured SCIM clients (downstream applications)",
+        value_type: :boolean,
+        default_value: false,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :scim_client_request_delay_ms,
+        description:
+          "Minimum delay in milliseconds between consecutive SCIM outbound requests to the same provider. Higher values reduce load on downstream systems. Must be between 50ms and 5000ms.",
+        value_type: :integer,
+        default_value: 100,
+        required: false,
+        validation_fn: &validate_scim_request_delay/1
+      },
+      # MFA (Multi-Factor Authentication) settings
+      %{
+        name: :require_mfa,
+        description:
+          "Require all users in this organization to enable multi-factor authentication",
+        value_type: :boolean,
+        default_value: false,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :mfa_lockout_enabled,
+        description: "Enable account lockout after failed MFA verification attempts",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :mfa_lockout_attempts,
+        description: "Number of failed MFA attempts before account lockout (1-10)",
+        value_type: :integer,
+        default_value: 5,
+        required: false,
+        validation_fn: &validate_mfa_attempts/1
+      },
+      %{
+        name: :mfa_lockout_duration_minutes,
+        description: "Duration of MFA lockout in minutes (1-60)",
+        value_type: :integer,
+        default_value: 5,
+        required: false,
+        validation_fn: &validate_lockout_duration/1
+      }
+    ]
+  end
+
+  # Profile/branding fields
+  defp profile_settings do
+    [
+      %{
+        name: :description,
+        description: "Organization description",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_description/1
+      },
+      %{
+        name: :website_url,
+        description: "Organization website URL",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_url/1
+      },
+      %{
+        name: :contact_email,
+        description: "Organization contact email",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_email/1
+      },
+      %{
+        name: :logo_url,
+        description: "Organization logo URL",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_url/1
+      }
+    ]
+  end
+
+  # Domain configuration
+  defp domain_settings do
+    [
+      %{
+        name: :email_link_domain,
+        description:
+          "Domain used in email links (invitations, password reset, etc.). Must be either the organization's subdomain or one of its configured CNAMEs.",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: nil
+      }
+    ]
+  end
+
+  # SMTP configuration
+  defp smtp_settings do
+    [
+      %{
+        name: :smtp_server,
+        description: "SMTP server hostname (e.g., smtp.gmail.com)",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_smtp_server/1
+      },
+      %{
+        name: :smtp_port,
+        description: "SMTP server port (typically 587 for TLS, 465 for SSL, 25 for unencrypted)",
+        value_type: :integer,
+        default_value: 587,
+        required: false,
+        validation_fn: &validate_smtp_port/1
+      },
+      %{
+        name: :smtp_username,
+        description: "SMTP authentication username",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :smtp_password,
+        description: "SMTP authentication password",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: nil,
+        encrypted: true
+      },
+      %{
+        name: :smtp_from_email,
+        description: "Email address to use in the 'From' field",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: &validate_email/1
+      },
+      %{
+        name: :smtp_from_name,
+        description: "Name to use in the 'From' field (e.g., 'Acme Corp')",
+        value_type: :string,
+        default_value: nil,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :smtp_use_ssl,
+        description: "Use SSL/TLS for SMTP connection",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      }
+    ]
   end
 
   @impl true
@@ -250,6 +272,68 @@ defmodule Authify.Configurations.Schemas.Organization do
     else
       {:error, "unknown setting: #{setting_name}"}
     end
+  end
+
+  # Password policy settings (organization admin configurable)
+  defp password_policy_settings do
+    [
+      %{
+        name: :password_min_length,
+        description: "Minimum password length (6-100)",
+        value_type: :integer,
+        default_value: 8,
+        required: false,
+        validation_fn: &validate_password_min_length/1
+      },
+      %{
+        name: :password_max_length,
+        description: "Maximum password length (password_min_length-200)",
+        value_type: :integer,
+        default_value: 100,
+        required: false,
+        validation_fn: &validate_password_max_length/1
+      },
+      %{
+        name: :password_require_uppercase,
+        description: "Require at least one uppercase letter in passwords",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :password_require_lowercase,
+        description: "Require at least one lowercase letter in passwords",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :password_require_digit,
+        description: "Require at least one number in passwords",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :password_require_special,
+        description: "Require at least one special character in passwords",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      },
+      %{
+        name: :password_common_blocklist_enabled,
+        description: "Reject passwords on the common-password blocklist",
+        value_type: :boolean,
+        default_value: true,
+        required: false,
+        validation_fn: nil
+      }
+    ]
   end
 
   # Rate limit quota settings (super admin only)
@@ -550,4 +634,30 @@ defmodule Authify.Configurations.Schemas.Organization do
   end
 
   defp validate_scim_request_delay(_), do: {:error, "Must be an integer"}
+
+  defp validate_password_min_length(nil), do: {:ok, nil}
+
+  defp validate_password_min_length(value)
+       when is_integer(value) and value >= 6 and value <= 100 do
+    {:ok, value}
+  end
+
+  defp validate_password_min_length(value) when is_integer(value) do
+    {:error, "Must be between 6 and 100"}
+  end
+
+  defp validate_password_min_length(_), do: {:error, "Must be an integer"}
+
+  defp validate_password_max_length(nil), do: {:ok, nil}
+
+  defp validate_password_max_length(value)
+       when is_integer(value) and value > 0 and value <= 200 do
+    {:ok, value}
+  end
+
+  defp validate_password_max_length(value) when is_integer(value) do
+    {:error, "Must be between 1 and 200"}
+  end
+
+  defp validate_password_max_length(_), do: {:error, "Must be an integer"}
 end

--- a/lib/authify/password_policy.ex
+++ b/lib/authify/password_policy.ex
@@ -1,0 +1,263 @@
+defmodule Authify.PasswordPolicy do
+  @moduledoc """
+  Resolves and applies per-organization password complexity policies.
+
+  The effective policy for an organization is derived from its organization
+  settings, falling back to a strict global default that matches Authify's
+  historical hardcoded rules. This lets individual organizations relax (or
+  further tighten) password requirements without affecting other tenants.
+  """
+
+  alias Authify.Configurations
+
+  @default_policy %{
+    password_min_length: 8,
+    password_max_length: 100,
+    password_require_uppercase: true,
+    password_require_lowercase: true,
+    password_require_digit: true,
+    password_require_special: true,
+    password_common_blocklist_enabled: true
+  }
+
+  @common_passwords [
+    "password",
+    "123456",
+    "12345678",
+    "qwerty",
+    "abc123",
+    "password123",
+    "admin",
+    "letmein",
+    "welcome",
+    "monkey",
+    "1234567890",
+    "password1",
+    "123456789",
+    "welcome123",
+    "admin123",
+    "root",
+    "toor",
+    "pass",
+    "test",
+    "guest",
+    "user",
+    "demo",
+    "temp",
+    "changeme",
+    "default"
+  ]
+
+  @doc """
+  Returns the strict default policy, matching Authify's historical behavior.
+  """
+  def default_policy, do: @default_policy
+
+  @doc """
+  Resolves the effective password policy for an organization.
+
+  Accepts an organization id, an `%Organization{}` struct, or `nil` (which
+  yields the global default policy).
+  """
+  def resolve(nil), do: @default_policy
+  def resolve(%{id: organization_id}), do: resolve(organization_id)
+
+  def resolve(organization_id) when is_integer(organization_id) do
+    Configurations.get_or_create_configuration("Organization", organization_id, "organization")
+
+    Enum.reduce(@default_policy, %{}, fn {key, default}, acc ->
+      value = Configurations.get_setting("Organization", organization_id, key)
+      Map.put(acc, key, if(is_nil(value), do: default, else: value))
+    end)
+  end
+
+  @doc """
+  Validates a password against a policy.
+
+  Applies length and complexity validations to the `:password` field of the
+  given changeset. Confirmation matching is intentionally left to the caller so
+  it can be applied regardless of policy.
+  """
+  def validate_password(%Ecto.Changeset{} = changeset, policy) do
+    changeset
+    |> validate_length(policy)
+    |> validate_complexity(policy)
+  end
+
+  @doc """
+  Returns a human-readable list of the requirements imposed by a policy, suitable
+  for display in password input hints.
+  """
+  def describe(policy) do
+    [
+      "At least #{policy.password_min_length} characters"
+    ] ++
+      maybe(:uppercase, policy.password_require_uppercase) ++
+      maybe(:lowercase, policy.password_require_lowercase) ++
+      maybe(:digit, policy.password_require_digit) ++
+      maybe(:special, policy.password_require_special)
+  end
+
+  defp maybe(_kind, value) when value in [false, nil], do: []
+
+  defp maybe(kind, _value) when kind in [:uppercase, :lowercase, :digit, :special] do
+    [
+      case kind do
+        :uppercase -> "At least one uppercase letter (A-Z)"
+        :lowercase -> "At least one lowercase letter (a-z)"
+        :digit -> "At least one number (0-9)"
+        :special -> "At least one special character (!@#$%^&*()_+-=[]{}|;:,.<>?)"
+      end
+    ]
+  end
+
+  @doc """
+  Generates a random password that satisfies the given policy.
+  """
+  def generate(policy) do
+    required =
+      [
+        {policy.password_require_uppercase, fn -> random_chars(?A..?Z, 3) end},
+        {policy.password_require_lowercase, fn -> random_chars(?a..?z, 3) end},
+        {policy.password_require_digit, fn -> random_chars(?0..?9, 3) end},
+        {policy.password_require_special, fn -> random_chars(~c"!@#$%^&*", 3) end}
+      ]
+      |> Enum.flat_map(fn {enabled, generator} ->
+        if enabled, do: [generator.()], else: []
+      end)
+
+    min_length = max(policy.password_min_length, length(required))
+
+    padding =
+      random_chars(valid_character_set(policy), max(0, min_length - length(required)))
+
+    (required ++ [padding])
+    |> Enum.join()
+    |> String.graphemes()
+    |> Enum.shuffle()
+    |> Enum.join()
+  end
+
+  defp validate_length(changeset, policy) do
+    Ecto.Changeset.validate_length(changeset, :password,
+      min: policy.password_min_length,
+      max: policy.password_max_length,
+      message:
+        "must be between #{policy.password_min_length} and #{policy.password_max_length} characters"
+    )
+  end
+
+  defp validate_complexity(changeset, policy) do
+    case Ecto.Changeset.get_change(changeset, :password) do
+      nil ->
+        changeset
+
+      password when is_binary(password) ->
+        changeset
+        |> maybe_require_uppercase(password, policy)
+        |> maybe_require_lowercase(password, policy)
+        |> maybe_require_digit(password, policy)
+        |> maybe_require_special(password, policy)
+        |> maybe_block_common(password, policy)
+
+      _ ->
+        changeset
+    end
+  end
+
+  defp maybe_require_uppercase(changeset, _password, %{password_require_uppercase: false}) do
+    changeset
+  end
+
+  defp maybe_require_uppercase(changeset, password, _policy) do
+    if Regex.match?(~r/[A-Z]/, password) do
+      changeset
+    else
+      Ecto.Changeset.add_error(changeset, :password, "must contain at least one uppercase letter")
+    end
+  end
+
+  defp maybe_require_lowercase(changeset, _password, %{password_require_lowercase: false}) do
+    changeset
+  end
+
+  defp maybe_require_lowercase(changeset, password, _policy) do
+    if Regex.match?(~r/[a-z]/, password) do
+      changeset
+    else
+      Ecto.Changeset.add_error(changeset, :password, "must contain at least one lowercase letter")
+    end
+  end
+
+  defp maybe_require_digit(changeset, _password, %{password_require_digit: false}) do
+    changeset
+  end
+
+  defp maybe_require_digit(changeset, password, _policy) do
+    if Regex.match?(~r/[0-9]/, password) do
+      changeset
+    else
+      Ecto.Changeset.add_error(changeset, :password, "must contain at least one number")
+    end
+  end
+
+  defp maybe_require_special(changeset, _password, %{password_require_special: false}) do
+    changeset
+  end
+
+  defp maybe_require_special(changeset, password, _policy) do
+    if Regex.match?(~r/[^A-Za-z0-9]/, password) do
+      changeset
+    else
+      Ecto.Changeset.add_error(
+        changeset,
+        :password,
+        "must contain at least one special character (!@#$%^&*()_+-=[]{}|;:,.<>?)"
+      )
+    end
+  end
+
+  defp maybe_block_common(changeset, _password, %{password_common_blocklist_enabled: false}) do
+    changeset
+  end
+
+  defp maybe_block_common(changeset, password, _policy) do
+    if String.downcase(password) in @common_passwords do
+      Ecto.Changeset.add_error(
+        changeset,
+        :password,
+        "is too common, please choose a more secure password"
+      )
+    else
+      changeset
+    end
+  end
+
+  defp random_chars(range_or_list, count) do
+    Enum.take_random(range_or_list, count)
+    |> List.to_string()
+  end
+
+  defp valid_character_set(policy) do
+    set =
+      %{}
+      |> then(fn set ->
+        if policy.password_require_uppercase, do: Map.put(set, :upper, ?A..?Z), else: set
+      end)
+      |> then(fn set ->
+        if policy.password_require_lowercase, do: Map.put(set, :lower, ?a..?z), else: set
+      end)
+      |> then(fn set ->
+        if policy.password_require_digit, do: Map.put(set, :digit, ?0..?9), else: set
+      end)
+      |> then(fn set ->
+        if policy.password_require_special, do: Map.put(set, :special, ~c"!@#$%^&*"), else: set
+      end)
+      |> Map.values()
+      |> Enum.flat_map(&Enum.to_list/1)
+
+    # Always guarantee at least a usable charset so the generated password is
+    # never empty, even when every character class is disabled.
+    if set == [], do: Enum.to_list(?a..?z), else: set
+  end
+end

--- a/lib/authify/scim/provisioning.ex
+++ b/lib/authify/scim/provisioning.ex
@@ -241,7 +241,8 @@ defmodule Authify.SCIM.Provisioning do
   def create_user_scim(attrs, organization_id) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    password = generate_random_password()
+    policy = Authify.PasswordPolicy.resolve(organization_id)
+    password = generate_random_password(policy)
 
     attrs =
       attrs
@@ -253,7 +254,7 @@ defmodule Authify.SCIM.Provisioning do
 
     result =
       %User{}
-      |> User.registration_changeset(attrs)
+      |> User.registration_changeset(attrs, policy)
       |> User.apply_scim_timestamps(attrs)
       |> Repo.insert()
 
@@ -390,16 +391,8 @@ defmodule Authify.SCIM.Provisioning do
     end
   end
 
-  defp generate_random_password do
-    upper = Enum.take_random(?A..?Z, 6) |> List.to_string()
-    lower = Enum.take_random(?a..?z, 6) |> List.to_string()
-    digits = Enum.take_random(?0..?9, 6) |> List.to_string()
-    special = Enum.take_random(~c"!@#$%^&*", 6) |> List.to_string()
-
-    (upper <> lower <> digits <> special)
-    |> String.graphemes()
-    |> Enum.shuffle()
-    |> Enum.join()
+  defp generate_random_password(policy) do
+    Authify.PasswordPolicy.generate(policy)
   end
 
   @doc """

--- a/lib/authify_web/controllers/configuration_html/show.html.heex
+++ b/lib/authify_web/controllers/configuration_html/show.html.heex
@@ -540,6 +540,158 @@
                   </div>
                 </div>
 
+                <h6 class="border-bottom pb-2 mb-3 mt-4">Password Policy</h6>
+                <p class="text-muted small">
+                  Configure the password complexity requirements users in this
+                  organization must satisfy when registering, resetting, or
+                  changing their password. Defaults match Authify's strict
+                  security baseline.
+                </p>
+
+                <div class="row">
+                  <div class="col-md-6 mb-4">
+                    <label for="password_min_length" class="form-label">
+                      <strong>Minimum Length</strong>
+                    </label>
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="password_min_length"
+                      name="settings[password_min_length]"
+                      value={@settings[:password_min_length]}
+                      placeholder="8"
+                      min="6"
+                      max="100"
+                    />
+                    <small class="text-muted">
+                      Minimum password length. Range: 6-100 (default: 8).
+                    </small>
+                  </div>
+
+                  <div class="col-md-6 mb-4">
+                    <label for="password_max_length" class="form-label">
+                      <strong>Maximum Length</strong>
+                    </label>
+                    <input
+                      type="number"
+                      class="form-control"
+                      id="password_max_length"
+                      name="settings[password_max_length]"
+                      value={@settings[:password_max_length]}
+                      placeholder="100"
+                      min="1"
+                      max="200"
+                    />
+                    <small class="text-muted">
+                      Maximum password length. Range: 1-200 (default: 100).
+                    </small>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md-6 mb-4">
+                    <div class="form-check form-switch">
+                      <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        id="password_require_uppercase"
+                        name="settings[password_require_uppercase]"
+                        value="true"
+                        checked={@settings[:password_require_uppercase] != false}
+                      />
+                      <label class="form-check-label" for="password_require_uppercase">
+                        <strong>Require Uppercase Letter</strong>
+                      </label>
+                    </div>
+                    <small class="text-muted ms-4 d-block">
+                      Passwords must contain at least one uppercase letter (A-Z).
+                    </small>
+                  </div>
+
+                  <div class="col-md-6 mb-4">
+                    <div class="form-check form-switch">
+                      <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        id="password_require_lowercase"
+                        name="settings[password_require_lowercase]"
+                        value="true"
+                        checked={@settings[:password_require_lowercase] != false}
+                      />
+                      <label class="form-check-label" for="password_require_lowercase">
+                        <strong>Require Lowercase Letter</strong>
+                      </label>
+                    </div>
+                    <small class="text-muted ms-4 d-block">
+                      Passwords must contain at least one lowercase letter (a-z).
+                    </small>
+                  </div>
+                </div>
+
+                <div class="row">
+                  <div class="col-md-6 mb-4">
+                    <div class="form-check form-switch">
+                      <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        id="password_require_digit"
+                        name="settings[password_require_digit]"
+                        value="true"
+                        checked={@settings[:password_require_digit] != false}
+                      />
+                      <label class="form-check-label" for="password_require_digit">
+                        <strong>Require Number</strong>
+                      </label>
+                    </div>
+                    <small class="text-muted ms-4 d-block">
+                      Passwords must contain at least one number (0-9).
+                    </small>
+                  </div>
+
+                  <div class="col-md-6 mb-4">
+                    <div class="form-check form-switch">
+                      <input
+                        class="form-check-input"
+                        type="checkbox"
+                        role="switch"
+                        id="password_require_special"
+                        name="settings[password_require_special]"
+                        value="true"
+                        checked={@settings[:password_require_special] != false}
+                      />
+                      <label class="form-check-label" for="password_require_special">
+                        <strong>Require Special Character</strong>
+                      </label>
+                    </div>
+                    <small class="text-muted ms-4 d-block">
+                      Passwords must contain at least one special character (!@#$%^&amp;*()_+-=[]{}|;:,.&lt;&gt;?).
+                    </small>
+                  </div>
+                </div>
+
+                <div class="mb-4">
+                  <div class="form-check form-switch">
+                    <input
+                      class="form-check-input"
+                      type="checkbox"
+                      role="switch"
+                      id="password_common_blocklist_enabled"
+                      name="settings[password_common_blocklist_enabled]"
+                      value="true"
+                      checked={@settings[:password_common_blocklist_enabled] != false}
+                    />
+                    <label class="form-check-label" for="password_common_blocklist_enabled">
+                      <strong>Reject Common Passwords</strong>
+                    </label>
+                  </div>
+                  <small class="text-muted ms-4 d-block">
+                    Reject passwords on the common-password blocklist (e.g., "password", "123456").
+                  </small>
+                </div>
+
                 <h6 class="border-bottom pb-2 mb-3 mt-4">Domain Configuration</h6>
 
                 <div class="mb-4">
@@ -826,6 +978,9 @@
                 <% end %>
                 <li>
                   <strong>Rate Limits</strong> - Configure request rate limits per endpoint type
+                </li>
+                <li>
+                  <strong>Password Policy</strong> - Configure password complexity requirements
                 </li>
                 <li>
                   <strong>Domain Configuration</strong> - Set custom domains and email link domain

--- a/lib/authify_web/controllers/invitation_controller.ex
+++ b/lib/authify_web/controllers/invitation_controller.ex
@@ -122,6 +122,7 @@ defmodule AuthifyWeb.InvitationController do
           render(conn, :accept,
             invitation: invitation,
             changeset: changeset,
+            password_policy: Authify.PasswordPolicy.resolve(invitation.organization),
             page_title: "Accept Invitation"
           )
         else
@@ -163,6 +164,7 @@ defmodule AuthifyWeb.InvitationController do
             render(conn, :accept,
               invitation: invitation,
               changeset: changeset,
+              password_policy: Authify.PasswordPolicy.resolve(invitation.organization),
               page_title: "Accept Invitation"
             )
 

--- a/lib/authify_web/controllers/invitation_html/accept.html.heex
+++ b/lib/authify_web/controllers/invitation_html/accept.html.heex
@@ -82,11 +82,9 @@
               <div class="form-text">
                 <small>Password must contain:</small>
                 <ul class="mb-0" style="font-size: 0.875em;">
-                  <li>At least 8 characters</li>
-                  <li>At least one uppercase letter (A-Z)</li>
-                  <li>At least one lowercase letter (a-z)</li>
-                  <li>At least one number (0-9)</li>
-                  <li>At least one special character (!@#$%^&amp;*()_+-=[]{}|;:,.&lt;&gt;?)</li>
+                  <li :for={requirement <- Authify.PasswordPolicy.describe(@password_policy)}>
+                    {requirement}
+                  </li>
                 </ul>
               </div>
             </div>

--- a/lib/authify_web/controllers/organization_controller.ex
+++ b/lib/authify_web/controllers/organization_controller.ex
@@ -15,6 +15,7 @@ defmodule AuthifyWeb.OrganizationController do
       render(conn, :new,
         organization_changeset: organization_changeset,
         user_changeset: user_changeset,
+        password_policy: Authify.PasswordPolicy.default_policy(),
         page_title: "Create Organization"
       )
     else
@@ -70,6 +71,7 @@ defmodule AuthifyWeb.OrganizationController do
         |> render(:new,
           organization_changeset: org_changeset,
           user_changeset: user_changeset,
+          password_policy: Authify.PasswordPolicy.default_policy(),
           page_title: "Create Organization"
         )
     end

--- a/lib/authify_web/controllers/organization_html/new.html.heex
+++ b/lib/authify_web/controllers/organization_html/new.html.heex
@@ -141,11 +141,9 @@
                 <div class="form-text">
                   <small>Password must contain:</small>
                   <ul class="mb-0" style="font-size: 0.875em;">
-                    <li>At least 8 characters</li>
-                    <li>At least one uppercase letter (A-Z)</li>
-                    <li>At least one lowercase letter (a-z)</li>
-                    <li>At least one number (0-9)</li>
-                    <li>At least one special character (!@#$%^&amp;*()_+-=[]{}|;:,.&lt;&gt;?)</li>
+                    <li :for={requirement <- Authify.PasswordPolicy.describe(@password_policy)}>
+                      {requirement}
+                    </li>
                   </ul>
                 </div>
                 <%= for {msg, _} <- (Keyword.get_values(@user_changeset.errors, :password) || []) do %>

--- a/lib/authify_web/controllers/password_reset_controller.ex
+++ b/lib/authify_web/controllers/password_reset_controller.ex
@@ -52,7 +52,12 @@ defmodule AuthifyWeb.PasswordResetController do
       %Accounts.User{} = user ->
         if Accounts.User.valid_password_reset_token?(user) do
           changeset = Accounts.change_user_password(user)
-          render(conn, :edit, token: token, changeset: changeset)
+
+          render(conn, :edit,
+            token: token,
+            changeset: changeset,
+            password_policy: Authify.PasswordPolicy.resolve(user.organization)
+          )
         else
           conn
           |> put_flash(:error, "Password reset link is invalid or has expired.")
@@ -108,7 +113,11 @@ defmodule AuthifyWeb.PasswordResetController do
           extra_metadata: %{"source" => "web"}
         )
 
-        render(conn, :edit, token: token, changeset: changeset)
+        render(conn, :edit,
+          token: token,
+          changeset: changeset,
+          password_policy: Authify.PasswordPolicy.resolve(user.organization)
+        )
     end
   end
 end

--- a/lib/authify_web/controllers/password_reset_html/edit.html.heex
+++ b/lib/authify_web/controllers/password_reset_html/edit.html.heex
@@ -79,12 +79,12 @@
             <i class="bi bi-shield-check"></i> Password Requirements
           </h6>
           <ul class="small mb-0">
-            <li>At least 8 characters long</li>
-            <li>At least one uppercase letter (A-Z)</li>
-            <li>At least one lowercase letter (a-z)</li>
-            <li>At least one number (0-9)</li>
-            <li>At least one special character (!@#$%^&*)</li>
-            <li>Cannot be a common password</li>
+            <li :for={requirement <- Authify.PasswordPolicy.describe(@password_policy)}>
+              {requirement}
+            </li>
+            <%= if @password_policy.password_common_blocklist_enabled do %>
+              <li>Cannot be a common password</li>
+            <% end %>
           </ul>
         </div>
       </div>

--- a/lib/authify_web/controllers/profile_controller.ex
+++ b/lib/authify_web/controllers/profile_controller.ex
@@ -73,7 +73,8 @@ defmodule AuthifyWeb.ProfileController do
     render(conn, :edit_password,
       user: current_user,
       organization: organization,
-      changeset: changeset
+      changeset: changeset,
+      password_policy: Authify.PasswordPolicy.resolve(organization)
     )
   end
 
@@ -102,7 +103,8 @@ defmodule AuthifyWeb.ProfileController do
           render(conn, :edit_password,
             user: current_user,
             organization: organization,
-            changeset: changeset
+            changeset: changeset,
+            password_policy: Authify.PasswordPolicy.resolve(organization)
           )
       end
     else
@@ -118,7 +120,8 @@ defmodule AuthifyWeb.ProfileController do
       render(conn, :edit_password,
         user: current_user,
         organization: organization,
-        changeset: changeset
+        changeset: changeset,
+        password_policy: Authify.PasswordPolicy.resolve(organization)
       )
     end
   end

--- a/lib/authify_web/controllers/profile_html/edit_password.html.heex
+++ b/lib/authify_web/controllers/profile_html/edit_password.html.heex
@@ -118,12 +118,12 @@
           <div class="card-body">
             <p class="small mb-2">Your new password must include:</p>
             <ul class="small mb-3">
-              <li>At least 8 characters long</li>
-              <li>At least one uppercase letter (A-Z)</li>
-              <li>At least one lowercase letter (a-z)</li>
-              <li>At least one number (0-9)</li>
-              <li>At least one special character (!@#$%^&*)</li>
-              <li>Cannot be a common password</li>
+              <li :for={requirement <- Authify.PasswordPolicy.describe(@password_policy)}>
+                {requirement}
+              </li>
+              <%= if @password_policy.password_common_blocklist_enabled do %>
+                <li>Cannot be a common password</li>
+              <% end %>
             </ul>
             <div class="alert alert-info">
               <small>

--- a/lib/authify_web/controllers/users_controller.ex
+++ b/lib/authify_web/controllers/users_controller.ex
@@ -431,7 +431,8 @@ defmodule AuthifyWeb.UsersController do
 
     render(conn, :new,
       changeset: changeset,
-      organization: organization
+      organization: organization,
+      password_policy: Authify.PasswordPolicy.resolve(organization)
     )
   end
 
@@ -550,7 +551,8 @@ defmodule AuthifyWeb.UsersController do
       {:error, changeset} ->
         render(conn, :new,
           changeset: changeset,
-          organization: organization
+          organization: organization,
+          password_policy: Authify.PasswordPolicy.resolve(organization)
         )
     end
   end

--- a/lib/authify_web/controllers/users_html/new.html.heex
+++ b/lib/authify_web/controllers/users_html/new.html.heex
@@ -127,12 +127,10 @@
                     <div class="form-text">
                       <small>Password must contain:</small>
                       <ul class="mb-0" style="font-size: 0.875em;">
-                        <li>At least 8 characters</li>
-                        <li>At least one uppercase letter (A-Z)</li>
-                        <li>At least one lowercase letter (a-z)</li>
-                        <li>At least one number (0-9)</li>
-                        <li>
-                          At least one special character (!@#$%^&amp;*()_+-=[]{}|;:,.&lt;&gt;?)
+                        <li :for={
+                          requirement <- Authify.PasswordPolicy.describe(@password_policy)
+                        }>
+                          {requirement}
                         </li>
                       </ul>
                     </div>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Authify.MixProject do
   def project do
     [
       app: :authify,
-      version: "0.19.3",
+      version: "0.20.0",
       elixir: "~> 1.20",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/authify/configurations_test.exs
+++ b/test/authify/configurations_test.exs
@@ -123,6 +123,59 @@ defmodule Authify.ConfigurationsTest do
       assert Configurations.get_setting("Organization", org1.id, :allow_saml) == false
       assert Configurations.get_setting("Organization", org2.id, :allow_saml) == true
     end
+
+    test "password policy settings validate and default correctly" do
+      org = organization_fixture()
+      Configurations.get_or_create_configuration("Organization", org.id, "organization")
+
+      schema = Authify.Configurations.Schemas.Organization
+
+      # Defaults
+      assert Configurations.get_setting("Organization", org.id, :password_min_length) == 8
+      assert Configurations.get_setting("Organization", org.id, :password_max_length) == 100
+
+      assert Configurations.get_setting("Organization", org.id, :password_require_uppercase) ==
+               true
+
+      assert Configurations.get_setting(
+               "Organization",
+               org.id,
+               :password_common_blocklist_enabled
+             ) == true
+
+      # Length validation
+      assert {:ok, _} =
+               Configurations.set_setting("Organization", org.id, :password_min_length, 6)
+
+      assert {:error, _} =
+               Configurations.set_setting("Organization", org.id, :password_min_length, 4)
+
+      assert {:error, _} =
+               Configurations.set_setting("Organization", org.id, :password_min_length, 101)
+
+      assert {:ok, _} =
+               Configurations.set_setting("Organization", org.id, :password_max_length, 200)
+
+      assert {:error, _} =
+               Configurations.set_setting("Organization", org.id, :password_max_length, 0)
+
+      # Boolean settings
+      assert {:ok, _} =
+               Configurations.set_setting(
+                 "Organization",
+                 org.id,
+                 :password_require_special,
+                 false
+               )
+
+      assert Configurations.get_setting("Organization", org.id, :password_require_special) ==
+               false
+
+      # Schema validates value
+      assert {:ok, true} = schema.validate_value(:password_require_uppercase, "true")
+      assert {:ok, 6} = schema.validate_value(:password_min_length, "6")
+      assert {:error, _} = schema.validate_value(:password_min_length, "abc")
+    end
   end
 
   describe "configuration value casting" do

--- a/test/authify/password_policy_test.exs
+++ b/test/authify/password_policy_test.exs
@@ -1,0 +1,189 @@
+defmodule Authify.PasswordPolicyTest do
+  use Authify.DataCase, async: true
+
+  import Authify.AccountsFixtures
+
+  alias Authify.{Accounts, Configurations, PasswordPolicy}
+
+  describe "resolve/1" do
+    test "returns strict default policy for nil" do
+      policy = PasswordPolicy.resolve(nil)
+
+      assert policy.password_min_length == 8
+      assert policy.password_max_length == 100
+      assert policy.password_require_uppercase == true
+      assert policy.password_require_lowercase == true
+      assert policy.password_require_digit == true
+      assert policy.password_require_special == true
+      assert policy.password_common_blocklist_enabled == true
+    end
+
+    test "returns strict default policy when organization has no overrides" do
+      org = organization_fixture()
+      policy = PasswordPolicy.resolve(org)
+
+      assert policy.password_min_length == 8
+      assert policy.password_require_uppercase == true
+    end
+
+    test "reflects organization overrides" do
+      org = organization_fixture()
+
+      Configurations.get_or_create_configuration("Organization", org.id, "organization")
+      {:ok, _} = Configurations.set_setting("Organization", org.id, :password_min_length, 6)
+
+      {:ok, _} =
+        Configurations.set_setting("Organization", org.id, :password_require_uppercase, false)
+
+      policy = PasswordPolicy.resolve(org)
+
+      assert policy.password_min_length == 6
+      assert policy.password_require_uppercase == false
+      assert policy.password_require_special == true
+    end
+  end
+
+  describe "configurable policy across password entry points" do
+    setup do
+      org = organization_fixture()
+      Configurations.get_or_create_configuration("Organization", org.id, "organization")
+
+      {:ok, _} = Configurations.set_setting("Organization", org.id, :password_min_length, 6)
+      {:ok, _} = Configurations.set_setting("Organization", org.id, :password_max_length, 64)
+
+      for setting <- [
+            :password_require_uppercase,
+            :password_require_lowercase,
+            :password_require_digit,
+            :password_require_special
+          ] do
+        {:ok, _} = Configurations.set_setting("Organization", org.id, setting, false)
+      end
+
+      {:ok, _} =
+        Configurations.set_setting(
+          "Organization",
+          org.id,
+          :password_common_blocklist_enabled,
+          false
+        )
+
+      %{org: org}
+    end
+
+    defp simple_password_attrs(org, password) do
+      %{
+        "organization_id" => org.id,
+        "first_name" => "Jane",
+        "last_name" => "Doe",
+        "email" => unique_user_email(),
+        "password" => password,
+        "password_confirmation" => password
+      }
+    end
+
+    test "allows a simple password on user registration", %{org: org} do
+      assert {:ok, _user} = Accounts.create_user(simple_password_attrs(org, "simple1"))
+    end
+
+    test "rejects a password shorter than the configured minimum", %{org: org} do
+      assert {:error, changeset} = Accounts.create_user(simple_password_attrs(org, "short"))
+      assert %{password: ["must be between 6 and 64 characters"]} = errors_on(changeset)
+    end
+
+    test "allows a simple password on password change", %{org: org} do
+      user = user_for_organization_fixture(org)
+
+      assert {:ok, _user} =
+               Accounts.update_user_password(user, %{
+                 "password" => "changed1",
+                 "password_confirmation" => "changed1"
+               })
+    end
+
+    test "allows a simple password on password reset", %{org: org} do
+      user = user_for_organization_fixture(org)
+      {:ok, _user, token} = Accounts.generate_password_reset_token(user)
+
+      assert {:ok, _reset_user} =
+               Accounts.reset_password_with_token(token, %{
+                 "password" => "resetpw1",
+                 "password_confirmation" => "resetpw1"
+               })
+    end
+
+    test "orgs with default settings still enforce strict policy" do
+      strict_org = organization_fixture()
+      attrs = simple_password_attrs(strict_org, "simple1")
+      assert {:error, changeset} = Accounts.create_user(attrs)
+      assert %{password: _} = errors_on(changeset)
+    end
+  end
+
+  describe "validate_password/2" do
+    alias Authify.Accounts.User
+
+    test "default policy rejects weak passwords" do
+      policy = PasswordPolicy.default_policy()
+
+      changeset =
+        User.changeset(
+          %User{},
+          %{"password" => "password", "password_confirmation" => "password"},
+          policy
+        )
+
+      refute changeset.valid?
+      assert %{password: [_ | _]} = errors_on(changeset)
+    end
+
+    test "lenient policy accepts weak passwords" do
+      policy = %{
+        password_min_length: 1,
+        password_max_length: 100,
+        password_require_uppercase: false,
+        password_require_lowercase: false,
+        password_require_digit: false,
+        password_require_special: false,
+        password_common_blocklist_enabled: false
+      }
+
+      changeset =
+        User.changeset(
+          %User{},
+          %{"password" => "simple", "password_confirmation" => "simple"},
+          policy
+        )
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "describe/1" do
+    test "lists all requirements for the strict default policy" do
+      requirements = PasswordPolicy.describe(PasswordPolicy.default_policy())
+
+      assert "At least 8 characters" in requirements
+      assert "At least one uppercase letter (A-Z)" in requirements
+      assert "At least one lowercase letter (a-z)" in requirements
+      assert "At least one number (0-9)" in requirements
+      assert "At least one special character (!@#$%^&*()_+-=[]{}|;:,.<>?)" in requirements
+    end
+
+    test "omits disabled requirements" do
+      policy = %{
+        password_min_length: 6,
+        password_max_length: 64,
+        password_require_uppercase: false,
+        password_require_lowercase: false,
+        password_require_digit: false,
+        password_require_special: false,
+        password_common_blocklist_enabled: false
+      }
+
+      requirements = PasswordPolicy.describe(policy)
+
+      assert requirements == ["At least 6 characters"]
+    end
+  end
+end

--- a/test/authify/scim/provisioning_test.exs
+++ b/test/authify/scim/provisioning_test.exs
@@ -146,6 +146,36 @@ defmodule Authify.SCIM.ProvisioningTest do
       refute User.valid_password?(user, "")
     end
 
+    test "create_user_scim generates password satisfying relaxed org policy", %{
+      organization: organization
+    } do
+      Authify.Configurations.get_or_create_configuration(
+        "Organization",
+        organization.id,
+        "organization"
+      )
+
+      for setting <- [
+            :password_require_uppercase,
+            :password_require_lowercase,
+            :password_require_digit,
+            :password_require_special
+          ] do
+        {:ok, _} =
+          Authify.Configurations.set_setting("Organization", organization.id, setting, false)
+      end
+
+      # Under a relaxed policy, provisioning a user must still succeed and the
+      # generated password must be accepted by the organization's policy.
+      assert {:ok, user} =
+               Provisioning.create_user_scim(
+                 scim_user_attrs(%{username: "scim-relaxed"}),
+                 organization.id
+               )
+
+      assert user.scim_created_at
+    end
+
     test "update_user_scim updates timestamp", %{organization: organization} do
       {:ok, user} = Provisioning.create_user_scim(scim_user_attrs(%{}), organization.id)
       original_updated_at = user.scim_updated_at


### PR DESCRIPTION
Closes #201

## Summary
Adds per-organization password complexity policy backed by the existing Configurations framework. Organization admins can tune password requirements (min/max length, required character classes, common-password blocklist) from the Configuration settings page, while the previous strict rules remain the global default so existing orgs see no change until they opt in.

## Changes
- New `Authify.PasswordPolicy` module: resolves the effective policy for an org (org settings -> strict default), validates passwords, and generates policy-compliant random passwords
- New `:password_*` org settings in the Configuration schema (min/max length, require uppercase/lowercase/digit/special, common-password blocklist) with validation
- Threads the resolved policy through all password entry points: registration, admin user creation, self-service change, password reset, invitation acceptance, and SCIM provisioning
- SCIM `create_user_scim` now generates and validates passwords against the org's policy
- Admin UI "Configuration" page gains a Password Policy section
- Password hint text across the UI (Add User, Accept Invitation, Change Password, Password Reset, Create Organization) reflects the org's effective policy

## Tests
- New `password_policy_test.exs` covering policy resolution, validation, and `describe/1`
- Additions to configurations and SCIM provisioning tests
- Full `mix precommit` passes (1984 tests, credo, sobelow)

Also bumps version to v0.20.0.